### PR TITLE
Clean up Game and AssetProvider classes

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
@@ -13,6 +13,7 @@ import com.lehaine.littlekt.graphics.gl.TexMagFilter
 import com.lehaine.littlekt.graphics.gl.TexMinFilter
 import com.lehaine.littlekt.graphics.tilemap.ldtk.LDtkLevel
 import com.lehaine.littlekt.graphics.tilemap.ldtk.LDtkWorld
+import com.lehaine.littlekt.util.internal.lock
 import kotlinx.atomicfu.atomic
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
@@ -24,15 +25,13 @@ open class AssetProvider(val context: Context) {
     private val loaders = createLoaders()
     private val assetsToPrepare = mutableListOf<PreparableGameAsset<*>>()
     private var totalAssetsLoading = atomic(0)
-    var onLoaded: (() -> Unit)? = null
+    private val filesBeingChecked = mutableListOf<VfsFile>()
+    private val _assets = mutableMapOf<KClass<*>, MutableMap<VfsFile, GameAsset<*>>>()
+    private val lock = Any()
+    val assets: Map<KClass<*>, Map<VfsFile, GameAsset<*>>> get() = _assets
 
-    /**
-     * Hold the current state of assets being loaded.
-     * @see loadAssets
-     * @see load
-     */
-    var loading = true
-        protected set
+    var onFullyLoaded: (() -> Unit)? = null
+
 
     /**
      * Holds the current state of assets being prepared.
@@ -42,48 +41,22 @@ open class AssetProvider(val context: Context) {
     var prepared = false
         protected set
 
-    val fullyLoaded get() = !loading && totalAssetsLoading.value == 0 && prepared
-
-    init {
-        context.vfs.launch {
-            loadAssets()
-            loading = false
-        }
-    }
-
-    /**
-     * This is triggered before anything else runs. Runs in a separate thread. Load any assets here.
-     * If an asset needs to be prepared, then prepare it in the [create] function.
-     */
-    open suspend fun loadAssets() {}
-
-    /**
-     * This is triggered after all assets have been loaded. Runs on the ui thread. Initialize any GL related
-     * objects here to ensure everything has been loaded.
-     */
-    open fun create() {}
+    val fullyLoaded get() = totalAssetsLoading.value == 0 && prepared
 
     /**
      * Handle any render / update logic here.
      */
     fun update() {
-        if (loading || totalAssetsLoading.value > 0) return
+        if (totalAssetsLoading.value > 0) return
         if (!prepared) {
             assetsToPrepare.forEach {
                 it.prepare()
             }
             assetsToPrepare.clear()
-            create()
             prepared = true
-            onFullyLoaded()
-            onLoaded?.invoke()
+            onFullyLoaded?.invoke()
         }
     }
-
-    /**
-     * Invoked when every asset has been loaded, prepared, and [create] triggered.
-     */
-    protected open fun onFullyLoaded() = Unit
 
     /**
      * Loads an asset asynchronously.
@@ -98,12 +71,25 @@ open class AssetProvider(val context: Context) {
         clazz: KClass<T>,
         parameters: GameAssetParameters = EmptyGameAssetParameter()
     ): GameAsset<T> {
-        val sceneAsset = GameAsset<T>(file)
+        val sceneAsset = _assets[clazz]?.get(file)?.let {
+            return it as GameAsset<T>
+        } ?: GameAsset<T>(file)
+
+        if (filesBeingChecked.contains(file)) {
+            throw IllegalStateException("'${file.path}' has already been triggered to load but hasn't finished yet!")
+        }
+        filesBeingChecked += file
         totalAssetsLoading.addAndGet(1)
         context.vfs.launch {
             val loader = loaders[clazz] ?: throw UnsupportedFileTypeException(file.path)
             val result = loader.invoke(file, parameters) as T
             sceneAsset.load(result)
+            lock(lock) {
+                _assets.getOrPut(clazz) { mutableMapOf() }.let {
+                    it[file] = sceneAsset
+                }
+                filesBeingChecked -= file
+            }
             totalAssetsLoading.addAndGet(-1)
         }
         return sceneAsset
@@ -131,6 +117,11 @@ open class AssetProvider(val context: Context) {
      */
     fun <T : Any> prepare(action: () -> T) = PreparableGameAsset(action).also { assetsToPrepare += it }
 
+    fun <T : Any> get(clazz: KClass<T>, vfsFile: VfsFile) = assets[clazz]?.get(vfsFile)?.content
+
+    inline fun <reified T : Any> get(
+        file: VfsFile,
+    ) = get(T::class, file)
 
     companion object {
         private fun createLoaders() = mapOf<KClass<*>, suspend (VfsFile, GameAssetParameters) -> Any>(
@@ -185,14 +176,9 @@ open class AssetProvider(val context: Context) {
 class GameAsset<T>(val vfsFile: VfsFile) {
     private var result: T? = null
     private var isLoaded = false
+    val content get() = if (isLoaded) result!! else throw IllegalStateException("Asset not loaded yet! ${vfsFile.path}")
 
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        if (isLoaded) {
-            return result!!
-        } else {
-            throw IllegalStateException("Asset not loaded yet! ${vfsFile.path}")
-        }
-    }
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T = content
 
     fun load(content: T) {
         result = content

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
@@ -22,14 +22,14 @@ import kotlin.reflect.KProperty
  * Provides helper functions to load and prepare assets without having to use `null` or `lateinit`.
  */
 open class AssetProvider(val context: Context) {
-    private val loaders = createLoaders()
     private val assetsToPrepare = mutableListOf<PreparableGameAsset<*>>()
     private var totalAssetsLoading = atomic(0)
     private val filesBeingChecked = mutableListOf<VfsFile>()
     private val _assets = mutableMapOf<KClass<*>, MutableMap<VfsFile, GameAsset<*>>>()
     private val lock = Any()
-    val assets: Map<KClass<*>, Map<VfsFile, GameAsset<*>>> get() = _assets
 
+    val loaders = createDefaultLoaders().toMutableMap()
+    val assets: Map<KClass<*>, Map<VfsFile, GameAsset<*>>> get() = _assets
     var onFullyLoaded: (() -> Unit)? = null
 
 
@@ -131,7 +131,7 @@ open class AssetProvider(val context: Context) {
     ) = get(T::class, file)
 
     companion object {
-        private fun createLoaders() = mapOf<KClass<*>, suspend (VfsFile, GameAssetParameters) -> Any>(
+        fun createDefaultLoaders() = mapOf<KClass<*>, suspend (VfsFile, GameAssetParameters) -> Any>(
             Texture::class to { file, param ->
                 if (param is TextureGameAssetParameter) {
                     file.readTexture(param.minFilter, param.magFilter, param.useMipmaps)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
@@ -41,7 +41,14 @@ open class AssetProvider(val context: Context) {
     var prepared = false
         protected set
 
-    val fullyLoaded get() = totalAssetsLoading.value == 0 && prepared
+    /**
+     * Calls [update] to get the latest assets loaded to determine if is has been fully loaded.
+     */
+    val fullyLoaded: Boolean
+        get() {
+            update()
+            return totalAssetsLoading.value == 0 && prepared
+        }
 
     /**
      * Handle any render / update logic here.
@@ -76,7 +83,7 @@ open class AssetProvider(val context: Context) {
         } ?: GameAsset<T>(file)
 
         if (filesBeingChecked.contains(file)) {
-            throw IllegalStateException("'${file.path}' has already been triggered to load but hasn't finished yet!")
+            throw IllegalStateException("'${file.path}' has already been triggered to load but hasn't finished yet! Ensure `load()` hasn't been called twice for the same VfsFile")
         }
         filesBeingChecked += file
         totalAssetsLoading.addAndGet(1)

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
@@ -201,7 +201,7 @@ class LwjglContext(override val configuration: JvmConfiguration) : Context {
             }
         }
         while (!windowShouldClose) {
-            launch(Dispatchers.IO) {
+            launch {
                 audioContext.update()
             }
 

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
@@ -160,7 +160,9 @@ class LwjglContext(override val configuration: JvmConfiguration) : Context {
         GLFW.glfwShowWindow(windowHandle)
         input.attachToWindow(windowHandle)
 
-        LWJGL.createCapabilities()
+        launch {
+            LWJGL.createCapabilities()
+        }
         // GLUtil.setupDebugMessageCallback()
 
         GL30C.glClearColor(0f, 0f, 0f, 0f)

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -1,11 +1,7 @@
 package com.lehaine.littlekt.samples
 
-import com.lehaine.littlekt.Context
-import com.lehaine.littlekt.Game
-import com.lehaine.littlekt.Scene
-import com.lehaine.littlekt.createShader
+import com.lehaine.littlekt.*
 import com.lehaine.littlekt.file.vfs.readAtlas
-import com.lehaine.littlekt.file.vfs.readAudioClip
 import com.lehaine.littlekt.file.vfs.readAudioStream
 import com.lehaine.littlekt.file.vfs.readTexture
 import com.lehaine.littlekt.graphics.*
@@ -23,7 +19,8 @@ import com.lehaine.littlekt.log.Logger
  */
 class DisplayTest(context: Context) : Game<Scene>(context) {
 
-    val testLoad by load<Texture>(resourcesVfs["person.png"])
+    private val assetProvider = AssetProvider(context)
+    val testLoad by assetProvider.load<Texture>(resourcesVfs["person.png"])
 
     private var x = 0f
     private var y = 0f
@@ -98,7 +95,10 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
         )
     }
 
-    override suspend fun Context.run() {
+
+    override suspend fun Context.start() {
+        super.setSceneCallbacks(this)
+
         val batch = SpriteBatch(context)
         val texture = resourcesVfs["atlas.png"].readTexture()
         val atlas: TextureAtlas = resourcesVfs["tiles.atlas.json"].readAtlas()
@@ -123,6 +123,8 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
         }
 
         onRender { dt ->
+            if (!assetProvider.fullyLoaded) return@onRender
+
             xVel = 0f
             yVel = 0f
 


### PR DESCRIPTION
* Add an asset cache to `AssetProvider`
  * Prevent loading the exact same `VfsFile` if already loading or in progress
* Fix an issue with updating the audio context in `LwjglContext`
*  Make `createDefaultLoaders` and `loaders` map public and mutable
* Remove the internal `AssetProvider` in the `Game` class to allow custom provider