### PR TITLE
Fix FontCache/GlyphLayout color issues

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Color.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Color.kt
@@ -244,7 +244,7 @@ open class MutableColor(r: Float, g: Float, b: Float, a: Float) : Color(r, g, b,
     fun mul(other: Vec4f): MutableColor {
         r *= other.x
         g *= other.y
-        g *= other.z
+        b *= other.z
         a *= other.w
         return this
     }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/FontCache.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/FontCache.kt
@@ -8,6 +8,7 @@ import com.lehaine.littlekt.math.geom.cosine
 import com.lehaine.littlekt.math.geom.degrees
 import com.lehaine.littlekt.math.geom.sine
 import com.lehaine.littlekt.util.datastructure.FloatArrayList
+import com.lehaine.littlekt.util.datastructure.internal.fill
 
 /**
  * Caches glyph geometry to provide a fast way to render static textures without having recompute the glyph each time.
@@ -19,6 +20,7 @@ import com.lehaine.littlekt.util.datastructure.FloatArrayList
 open class FontCache(val pages: Int = 1) {
     private val temp4 = Mat4() // used for rotating text
     private val layouts = mutableListOf<GlyphLayout>()
+    private val tempGlyphCount = IntArray(pages)
 
     private var lastX = 0f
     private var lastY = 0f
@@ -70,7 +72,7 @@ open class FontCache(val pages: Int = 1) {
         val newTint = tint.toFloatBits()
         if (newTint == currentTint) return
         currentTint = newTint
-
+        tempGlyphCount.fill(0)
         layouts.forEach { layout ->
             val colors = layout.colors
             var colorsIndex = 0
@@ -82,10 +84,14 @@ open class FontCache(val pages: Int = 1) {
                 glyphs.forEach {
                     if (glyphIndex++ == nextColorGlyphIndex) {
                         tempColor.setAbgr8888(colors[++colorsIndex])
+                        println("before: $tempColor")
+                        println("tint: $tint")
                         lastColorFloatBits = tempColor.mul(tint).toFloatBits()
+                        println("after: $tempColor")
                         nextColorGlyphIndex = if (++colorsIndex < colors.size) colors[colorsIndex] else -1
                     }
-                    val offset = 2
+                    val offset = tempGlyphCount[it.page] * 20 + 2
+                    tempGlyphCount[it.page]++
                     val vertices = pageVertices[it.page]
                     vertices[offset] = lastColorFloatBits
                     vertices[offset + 5] = lastColorFloatBits

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/GlyphLayout.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/GlyphLayout.kt
@@ -17,7 +17,7 @@ class GlyphLayout {
     private val _runs = mutableListOf<GlyphRun>()
     val runs: List<GlyphRun> get() = _runs
 
-    private val _colors = MutableList(2) { 0 }
+    private val _colors = mutableListOf<Int>()
     val colors: List<Int> get() = _colors
 
     var width: Float = 0f
@@ -44,7 +44,8 @@ class GlyphLayout {
         val wrapOrTruncate = wrap || truncate != null
         var currentColor = color.abgr()
         val nextColor = currentColor
-        _colors[0] = currentColor
+        _colors += 0
+        _colors += currentColor
         var lastRun = false
         var y = 0f
         var runStart = 0
@@ -74,7 +75,7 @@ class GlyphLayout {
                     glyphCount += run.glyphs.size
 
                     if (nextColor != currentColor) {// TODO implement a markup
-                        if (_colors.size - 2 == glyphCount) {
+                        if (_colors[colors.size - 2] == glyphCount) {
                             _colors[colors.size - 1] = nextColor
                         } else {
                             _colors += glyphCount
@@ -153,6 +154,10 @@ class GlyphLayout {
 
     fun reset() {
         _runs.clear()
+        _colors.clear()
+        glyphCount = 0
+        width = 0f
+        height = 0f
     }
 
     private fun wrap(font: Font, scale: Float, first: GlyphRun, wrapIndex: Int): GlyphRun? {

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -10,6 +10,7 @@ import com.lehaine.littlekt.graph.node.node2d.ui.button
 import com.lehaine.littlekt.graph.node.node2d.ui.ninePatchRect
 import com.lehaine.littlekt.graph.sceneGraph
 import com.lehaine.littlekt.graphics.*
+import com.lehaine.littlekt.graphics.font.BitmapFontCache
 import com.lehaine.littlekt.graphics.shader.shaders.SimpleColorFragmentShader
 import com.lehaine.littlekt.graphics.shader.shaders.SimpleColorVertexShader
 import com.lehaine.littlekt.input.GameAxis
@@ -114,6 +115,10 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
         val bossAttack = atlas.getAnimation("bossAttack")
         val boss = AnimatedSprite(bossAttack.firstFrame)
         val pixelFont = resourcesVfs["m5x7_16.fnt"].readBitmapFont()
+        val cache = BitmapFontCache(pixelFont).also {
+            it.addText("Test cache", 200f, 50f, scaleX = 4f, scaleY = 4f)
+            it.tint(Color.RED)
+        }
         val ninepatchImg = resourcesVfs["bg_9.png"].readTexture()
         val ninepatch = NinePatch(ninepatchImg, 3, 3, 3, 4)
 
@@ -200,6 +205,7 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
                 it.draw(Textures.blue, 280f, 400f, scaleX = 5f, scaleY = 5f)
                 it.draw(Textures.black, 300f, 400f, scaleX = 5f, scaleY = 5f)
                 ninepatch.draw(it, 200f, 200f, 25f, 20f, scaleX = 5f, scaleY = 5f)
+                cache.draw(it)
             }
 
             scene.update(dt)


### PR DESCRIPTION
* glyph layout: clear colors, width, height, and glyph count on reset
* glyph layout: fix issue with not adding the current color to the colors list
* font cache: fix issue of calculating the glyph offset when tinting
* Fixes #53 