### PR TITLE
Add `MouseFilter` logic to UI

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Container.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Container.kt
@@ -42,6 +42,7 @@ open class Container : Control() {
     private var pendingSort = false
 
     init {
+        mouseFilter = MouseFilter.IGNORE
         debugColor = Color.RED
     }
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
@@ -261,6 +261,8 @@ open class Control : Node2D() {
     val colorOverrides by lazy { mutableMapOf<String, Color>() }
     val constantOverrides by lazy { mutableMapOf<String, Int>() }
 
+    var mouseFilter = MouseFilter.STOP
+
     private val tempRect = Rect()
 
     override val membersAndPropertiesString: String
@@ -345,7 +347,7 @@ open class Control : Node2D() {
     }
 
     fun hit(hx: Float, hy: Float): Control? {
-        if (!enabled) {
+        if (!enabled || mouseFilter == MouseFilter.NONE) {
             return null
         }
         nodes.forEachReversed {
@@ -355,10 +357,13 @@ open class Control : Node2D() {
                 return target
             }
         }
+        if (mouseFilter == MouseFilter.IGNORE) return null
+
         if (globalRotation == Angle.ZERO) {
             return if (hx >= globalX && hx < globalX + width && hy >= globalY && hy < globalY + height) this else null
         }
         // TODO determine hit target when rotated
+
         return null
     }
 
@@ -783,6 +788,23 @@ open class Control : Node2D() {
         clearThemeDrawableOverrides()
         clearThemeColorOverrides()
         return this
+    }
+
+    enum class MouseFilter {
+        /**
+         * Stops at the current [Control] which triggers an input event and does not go any further up the graph.
+         */
+        STOP,
+
+        /**
+         * Receives no input events for the current [Control] and its children.
+         */
+        NONE,
+
+        /**
+         * Ignores input events on the current [Control] but still allows events to its children.
+         */
+        IGNORE
     }
 }
 

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -128,6 +128,7 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
                 padding(10)
                 vBoxContainer {
                     separation = 20
+
                     button {
                         text = "Center Center"
                         onPressed += {


### PR DESCRIPTION
* Add `MouseFilter` to allow preventing / ignoring / handling input events on a `Control`. Closes #67 