### PR TITLE
Refactor GL version handling

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/Context.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/Context.kt
@@ -18,9 +18,13 @@ abstract class Context {
 
     enum class Platform {
         DESKTOP,
-        JS,
+        WEBGL,
+        WEBGL2,
         ANDROID,
-        IOS
+        IOS;
+
+        val isWebGl get() = this == WEBGL || this == WEBGL2
+        val isMobile get() = this == ANDROID || this == IOS
     }
 
     protected val renderCalls = mutableListOf<suspend (Duration) -> Unit>()

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/Graphics.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/Graphics.kt
@@ -32,8 +32,7 @@ interface Graphics {
     /**
      * @return if the current GL version is 3.0 or higher
      */
-    fun isGL30OrHigher() =
-        glVersion == GLVersion.GL_30 || glVersion == GLVersion.GL_32_PLUS || glVersion == GLVersion.WEBGL2
+    val isGL30 get() = gl.isG30
 
     /**
      * @param extension the extension name

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/Graphics.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/Graphics.kt
@@ -1,6 +1,9 @@
 package com.lehaine.littlekt
 
-import com.lehaine.littlekt.graphics.*
+import com.lehaine.littlekt.graphics.Cursor
+import com.lehaine.littlekt.graphics.GL
+import com.lehaine.littlekt.graphics.GLVersion
+import com.lehaine.littlekt.graphics.SystemCursor
 
 
 /**
@@ -27,7 +30,7 @@ interface Graphics {
     /**
      * @return the [GLVersion] of this Graphics instance
      */
-    val glVersion: GLVersion
+    val glVersion: GLVersion get() = gl.version
 
     /**
      * @return if the current GL version is 3.0 or higher

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
@@ -154,7 +154,7 @@ open class SceneGraph(
         }
 
         when (context.platform) {
-            Context.Platform.DESKTOP, Context.Platform.JS -> {
+            Context.Platform.DESKTOP, Context.Platform.WEBGL, Context.Platform.WEBGL2 -> {
                 mouseOverControl = fireEnterAndExit(mouseOverControl, mouseScreenX, mouseScreenY, Pointer.POINTER1)
             }
             else -> {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/BufferObjects.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/BufferObjects.kt
@@ -1,5 +1,6 @@
 package com.lehaine.littlekt.graphics
 
+import com.lehaine.littlekt.Context
 import com.lehaine.littlekt.Disposable
 import com.lehaine.littlekt.file.DataSource
 import com.lehaine.littlekt.file.FloatBuffer
@@ -24,7 +25,7 @@ class VertexBufferObject(val gl: GL, val isStatic: Boolean, numVertices: Int, va
         }
     private val glBuffer: GlBuffer = gl.createBuffer()
     private val vaoGl: GlVertexArray? =
-        if (gl.isGL30OrHigher() && gl.getGLVersion() != GLVersion.WEBGL2) gl.createVertexArray() else null
+        if (gl.isG30 && gl.version.platform != Context.Platform.WEBGL2) gl.createVertexArray() else null
     private val usage = if (isStatic) Usage.STATIC_DRAW else Usage.DYNAMIC_DRAW
     private var bound = false
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/BufferObjects.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/BufferObjects.kt
@@ -1,6 +1,5 @@
 package com.lehaine.littlekt.graphics
 
-import com.lehaine.littlekt.Context
 import com.lehaine.littlekt.Disposable
 import com.lehaine.littlekt.file.DataSource
 import com.lehaine.littlekt.file.FloatBuffer
@@ -24,8 +23,7 @@ class VertexBufferObject(val gl: GL, val isStatic: Boolean, numVertices: Int, va
             return field
         }
     private val glBuffer: GlBuffer = gl.createBuffer()
-    private val vaoGl: GlVertexArray? =
-        if (gl.isG30 && gl.version.platform != Context.Platform.WEBGL2) gl.createVertexArray() else null
+    private val vaoGl: GlVertexArray? = if (gl.isG30) gl.createVertexArray() else null
     private val usage = if (isStatic) Usage.STATIC_DRAW else Usage.DYNAMIC_DRAW
     private var bound = false
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
@@ -20,13 +20,6 @@ class GLVersion(
     val vendor: String = "N/A",
     val renderer: String = "N/A"
 ) {
-//    GL_32_PLUS,
-//    GL_30,
-//    GL_20,
-//    WEBGL,
-//    WEBGL2
-
-
     val major: Int
     val minor: Int
 
@@ -41,6 +34,11 @@ class GLVersion(
         minor = split[0].toInt()
     }
 
+    fun atleast(major: Int, minor: Int) = major >= this.major && minor >= this.minor
+
+    override fun toString(): String {
+        return "GLVersion(platform=$platform, vendor='$vendor', renderer='$renderer', major=$major, minor=$minor)"
+    }
 }
 
 /**
@@ -52,12 +50,6 @@ interface GL {
     val version: GLVersion
 
     val isG30: Boolean get() = version.major >= 3
-
-    /**
-     * @return if the current GL version is 3.0 or higher
-     */
-    fun isGL30OrHigher() = true
-    //  getGLVersion() == GLVersion.GL_30 || getGLVersion() == GLVersion.GL_32_PLUS || getGLVersion() == GLVersion.WEBGL2
 
     fun clearColor(r: Float, g: Float, b: Float, a: Float)
     fun clearColor(color: Color) = clearColor(color.r, color.g, color.b, color.a)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
@@ -1,6 +1,10 @@
 package com.lehaine.littlekt.graphics
 
-import com.lehaine.littlekt.file.*
+import com.lehaine.littlekt.Context
+import com.lehaine.littlekt.file.ByteBuffer
+import com.lehaine.littlekt.file.DataSource
+import com.lehaine.littlekt.file.FloatBuffer
+import com.lehaine.littlekt.file.IntBuffer
 import com.lehaine.littlekt.graphics.gl.*
 import com.lehaine.littlekt.math.Mat3
 import com.lehaine.littlekt.math.Mat4
@@ -10,12 +14,33 @@ import com.lehaine.littlekt.math.Mat4
  * @author Colton Daily
  * @date 11/20/2021
  */
-enum class GLVersion {
-    GL_32_PLUS,
-    GL_30,
-    GL_20,
-    WEBGL,
-    WEBGL2
+class GLVersion(
+    val platform: Context.Platform,
+    version: String = "-1.-1",
+    val vendor: String = "N/A",
+    val renderer: String = "N/A"
+) {
+//    GL_32_PLUS,
+//    GL_30,
+//    GL_20,
+//    WEBGL,
+//    WEBGL2
+
+
+    val major: Int
+    val minor: Int
+
+    init {
+        val split = if (platform == Context.Platform.DESKTOP) {
+            version.split(".")
+        } else {
+            version.removePrefix("WebGL ").split(".")
+        }
+
+        major = split[0].toInt()
+        minor = split[0].toInt()
+    }
+
 }
 
 /**
@@ -24,13 +49,15 @@ enum class GLVersion {
  */
 interface GL {
 
-    fun getGLVersion(): GLVersion
+    val version: GLVersion
+
+    val isG30: Boolean get() = version.major >= 3
 
     /**
      * @return if the current GL version is 3.0 or higher
      */
-    fun isGL30OrHigher() =
-        getGLVersion() == GLVersion.GL_30 || getGLVersion() == GLVersion.GL_32_PLUS || getGLVersion() == GLVersion.WEBGL2
+    fun isGL30OrHigher() = true
+    //  getGLVersion() == GLVersion.GL_30 || getGLVersion() == GLVersion.GL_32_PLUS || getGLVersion() == GLVersion.WEBGL2
 
     fun clearColor(r: Float, g: Float, b: Float, a: Float)
     fun clearColor(color: Color) = clearColor(color.r, color.g, color.b, color.a)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureData.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureData.kt
@@ -47,8 +47,14 @@ fun <T : TextureData> T.generateMipMap(
     }
 
     when (context.platform) {
-        Context.Platform.DESKTOP -> generateMipMapDesktop(context, target, pixmap, width, height)
-        Context.Platform.JS, Context.Platform.ANDROID, Context.Platform.IOS -> generateMipMapGLES20(
+        Context.Platform.DESKTOP, Context.Platform.WEBGL2 -> generateMipMapDesktop(
+            context,
+            target,
+            pixmap,
+            width,
+            height
+        )
+        Context.Platform.WEBGL, Context.Platform.ANDROID, Context.Platform.IOS -> generateMipMapGLES20(
             context,
             target,
             pixmap
@@ -119,7 +125,7 @@ private fun TextureData.generateMipMapDesktop(
 
     if (context.graphics.supportsExtension("GL_ARB_framebuffer_object")
         || context.graphics.supportsExtension("GL_EXT_framebuffer_object")
-        || context.graphics.isGL30OrHigher()
+        || context.graphics.isGL30
     ) {
         gl.texImage2D(
             target = target,

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
@@ -17,11 +17,9 @@ import org.khronos.webgl.get
  */
 class WebGL(val gl: WebGL2RenderingContext, private val engineStats: EngineStats) : GL {
     private var lastBoundBuffer: GlBuffer? = null
-    internal var glVersion = GLVersion.WEBGL2
-
-    override fun getGLVersion(): GLVersion {
-        return glVersion
-    }
+    internal var glVersion = GLVersion(Context.Platform.WEBGL)
+    override val version: GLVersion
+        get() = glVersion
 
     override fun clearColor(r: Float, g: Float, b: Float, a: Float) {
         engineStats.calls++
@@ -292,15 +290,21 @@ class WebGL(val gl: WebGL2RenderingContext, private val engineStats: EngineStats
     }
 
     override fun createVertexArray(): GlVertexArray {
-        throw RuntimeException("WebGL does not support 'createVertexArray'!")
+        engineStats.calls++
+        return GlVertexArray(gl.createVertexArray())
+        // throw RuntimeException("WebGL does not support 'createVertexArray'!")
     }
 
     override fun bindVertexArray(glVertexArray: GlVertexArray) {
-        throw RuntimeException("WebGL does not support 'bindVertexArray'!")
+        engineStats.calls++
+        gl.bindVertexArray(glVertexArray.delegate)
+        //throw RuntimeException("WebGL does not support 'bindVertexArray'!")
     }
 
     override fun bindDefaultVertexArray() {
-        throw RuntimeException("WebGL does not support 'bindDefaultVertexArray'!")
+        engineStats.calls++
+        gl.bindVertexArray(null)
+        // throw RuntimeException("WebGL does not support 'bindDefaultVertexArray'!")
     }
 
     override fun bindFrameBuffer(glFrameBuffer: GlFrameBuffer) {

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
@@ -15,11 +15,9 @@ import org.khronos.webgl.get
  * @author Colton Daily
  * @date 9/28/2021
  */
-class WebGL(val gl: WebGL2RenderingContext, private val engineStats: EngineStats) : GL {
+class WebGL(val gl: WebGL2RenderingContext, val platform: Context.Platform, private val engineStats: EngineStats) : GL {
     private var lastBoundBuffer: GlBuffer? = null
-    internal var glVersion = GLVersion(Context.Platform.WEBGL)
-    override val version: GLVersion
-        get() = glVersion
+    override val version: GLVersion = GLVersion(platform, if (platform == Context.Platform.WEBGL2) "3.0" else "2.0")
 
     override fun clearColor(r: Float, g: Float, b: Float, a: Float) {
         engineStats.calls++
@@ -291,17 +289,25 @@ class WebGL(val gl: WebGL2RenderingContext, private val engineStats: EngineStats
 
     override fun createVertexArray(): GlVertexArray {
         engineStats.calls++
-        return GlVertexArray(gl.createVertexArray())
+        return GlVertexArray(if (platform == Context.Platform.WEBGL2) gl.createVertexArray() else gl.createVertexArrayOES())
     }
 
     override fun bindVertexArray(glVertexArray: GlVertexArray) {
         engineStats.calls++
-        gl.bindVertexArray(glVertexArray.delegate)
+        if (platform == Context.Platform.WEBGL2) {
+            gl.bindVertexArray(glVertexArray.delegate)
+        } else {
+            gl.bindVertexArrayOES(glVertexArray.delegate)
+        }
     }
 
     override fun bindDefaultVertexArray() {
         engineStats.calls++
-        gl.bindVertexArray(null)
+        if (platform == Context.Platform.WEBGL2) {
+            gl.bindVertexArray(null)
+        } else {
+            gl.bindVertexArrayOES(null)
+        }
     }
 
     override fun bindFrameBuffer(glFrameBuffer: GlFrameBuffer) {

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
@@ -292,19 +292,16 @@ class WebGL(val gl: WebGL2RenderingContext, private val engineStats: EngineStats
     override fun createVertexArray(): GlVertexArray {
         engineStats.calls++
         return GlVertexArray(gl.createVertexArray())
-        // throw RuntimeException("WebGL does not support 'createVertexArray'!")
     }
 
     override fun bindVertexArray(glVertexArray: GlVertexArray) {
         engineStats.calls++
         gl.bindVertexArray(glVertexArray.delegate)
-        //throw RuntimeException("WebGL does not support 'bindVertexArray'!")
     }
 
     override fun bindDefaultVertexArray() {
         engineStats.calls++
         gl.bindVertexArray(null)
-        // throw RuntimeException("WebGL does not support 'bindDefaultVertexArray'!")
     }
 
     override fun bindFrameBuffer(glFrameBuffer: GlFrameBuffer) {

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLContext.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLContext.kt
@@ -13,7 +13,6 @@ import kotlinx.browser.window
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.w3c.dom.HTMLCanvasElement
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLContext.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLContext.kt
@@ -32,7 +32,7 @@ class WebGLContext(override val configuration: JsConfiguration) : Context() {
     override val vfs = WebVfs(this, logger, configuration.rootPath)
     override val resourcesVfs: VfsFile get() = vfs.root
     override val storageVfs: VfsFile get() = vfs.root
-    override val platform: Platform = Platform.JS
+    override val platform: Platform = Platform.WEBGL
 
     private lateinit var listener: ContextListener
     private var closed = false

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
@@ -65,11 +65,7 @@ class WebGLGraphics(val canvas: HTMLCanvasElement, engineStats: EngineStats) : G
     override val height: Int
         get() = _height
 
-    override val glVersion: GLVersion
-        get() = gl.version
-
     override fun supportsExtension(extension: String): Boolean {
-        gl as WebGL
         return gl.gl.getExtension("extension") != null
     }
 

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
@@ -1,11 +1,13 @@
 package com.lehaine.littlekt
 
 import com.lehaine.littlekt.graphics.Cursor
-import com.lehaine.littlekt.graphics.GL
 import com.lehaine.littlekt.graphics.GLVersion
 import com.lehaine.littlekt.graphics.SystemCursor
 import com.lehaine.littlekt.util.internal.jsObject
-import org.khronos.webgl.*
+import org.khronos.webgl.ArrayBufferView
+import org.khronos.webgl.Float32Array
+import org.khronos.webgl.WebGLObject
+import org.khronos.webgl.WebGLRenderingContext
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.HTMLImageElement
@@ -20,11 +22,11 @@ import org.w3c.dom.events.UIEvent
 class WebGLGraphics(val canvas: HTMLCanvasElement, engineStats: EngineStats) : Graphics {
 
     @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    override val gl: GL
+    override val gl: WebGL
 
     internal var _width: Int = 0
     internal var _height: Int = 0
-    val platform: Context.Platform
+    private var platform: Context.Platform = Context.Platform.WEBGL2
 
     private val ctxOptions: dynamic = jsObject { stencil = true }
 
@@ -32,7 +34,6 @@ class WebGLGraphics(val canvas: HTMLCanvasElement, engineStats: EngineStats) : G
         var webGlCtx = canvas.getContext("webgl2", ctxOptions)
         if (webGlCtx == null) {
             webGlCtx = canvas.getContext("experimental-webgl2", ctxOptions)
-            platform = Context.Platform.WEBGL2
         }
         if (webGlCtx == null) {
             console.warn("WebGL2 not available. Attempting to fallback to WebGL.")
@@ -42,6 +43,7 @@ class WebGLGraphics(val canvas: HTMLCanvasElement, engineStats: EngineStats) : G
 
         if (webGlCtx != null) {
             gl = WebGL(webGlCtx as WebGL2RenderingContext, engineStats)
+            gl.glVersion = GLVersion(platform, if (platform == Context.Platform.WEBGL2) "3.0" else "2.0")
         } else {
             js("alert(\"Unable to initialize WebGL or WebGL2 context. Your browser may not support it.\")")
             throw RuntimeException("WebGL2 context required")
@@ -64,7 +66,7 @@ class WebGLGraphics(val canvas: HTMLCanvasElement, engineStats: EngineStats) : G
         get() = _height
 
     override val glVersion: GLVersion
-        get() = version
+        get() = gl.version
 
     override fun supportsExtension(extension: String): Boolean {
         gl as WebGL

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
@@ -42,8 +42,7 @@ class WebGLGraphics(val canvas: HTMLCanvasElement, engineStats: EngineStats) : G
         }
 
         if (webGlCtx != null) {
-            gl = WebGL(webGlCtx as WebGL2RenderingContext, engineStats)
-            gl.glVersion = GLVersion(platform, if (platform == Context.Platform.WEBGL2) "3.0" else "2.0")
+            gl = WebGL(webGlCtx as WebGL2RenderingContext, platform, engineStats)
         } else {
             js("alert(\"Unable to initialize WebGL or WebGL2 context. Your browser may not support it.\")")
             throw RuntimeException("WebGL2 context required")
@@ -170,6 +169,10 @@ abstract external class WebGL2RenderingContext : WebGLRenderingContext {
     fun createVertexArray(): WebGLVertexArrayObject
     fun bindVertexArray(vao: WebGLVertexArrayObject?)
     fun deleteVertexArray(vao: WebGLVertexArrayObject?)
+
+    fun createVertexArrayOES(): WebGLVertexArrayObject
+    fun bindVertexArrayOES(vao: WebGLVertexArrayObject?)
+    fun deleteVertexArrayOES(vao: WebGLVertexArrayObject?)
 
     companion object {
         val COLOR: Int

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/graphics/gl/GlVertexArray.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/graphics/gl/GlVertexArray.kt
@@ -1,7 +1,9 @@
 package com.lehaine.littlekt.graphics.gl
 
+import com.lehaine.littlekt.WebGLVertexArrayObject
+
 /**
  * @author Colton Daily
  * @date 11/20/2021
  */
-actual class GlVertexArray
+actual class GlVertexArray(val delegate: WebGLVertexArrayObject)

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
@@ -20,6 +20,7 @@ import org.lwjgl.glfw.Callbacks
 import org.lwjgl.glfw.GLFW
 import org.lwjgl.glfw.GLFWErrorCallback
 import org.lwjgl.glfw.GLFWImage
+import org.lwjgl.opengl.GL11
 import org.lwjgl.opengl.GL11.glClear
 import org.lwjgl.opengl.GL30
 import org.lwjgl.opengl.GL30C
@@ -70,11 +71,19 @@ class LwjglContext(override val configuration: JvmConfiguration) : Context() {
         // Create temporary window for getting OpenGL Version
         GLFW.glfwDefaultWindowHints()
         GLFW.glfwWindowHint(GLFW.GLFW_VISIBLE, GLFW.GLFW_FALSE)
+
         val temp: Long = GLFW.glfwCreateWindow(1, 1, "", MemoryUtil.NULL, MemoryUtil.NULL)
         GLFW.glfwMakeContextCurrent(temp)
+
         LWJGL.createCapabilities()
         val caps: GLCapabilities = LWJGL.getCapabilities()
+        val versionString = GL11.glGetString(GL11.GL_VERSION) ?: ""
+        val vendorString = GL11.glGetString(GL11.GL_VENDOR) ?: ""
+        val rendererString = GL11.glGetString(GL11.GL_RENDERER) ?: ""
+        graphics.gl.glVersion = GLVersion(platform, versionString, vendorString, rendererString)
+
         GLFW.glfwDestroyWindow(temp)
+
 
         // Configure GLFW
         GLFW.glfwDefaultWindowHints() // optional, the current window hints are already the default
@@ -85,19 +94,16 @@ class LwjglContext(override val configuration: JvmConfiguration) : Context() {
                 GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, 2)
                 GLFW.glfwWindowHint(GLFW.GLFW_OPENGL_PROFILE, GLFW.GLFW_OPENGL_CORE_PROFILE)
                 GLFW.glfwWindowHint(GLFW.GLFW_OPENGL_FORWARD_COMPAT, GL30.GL_TRUE)
-                graphics._glVersion = GLVersion.GL_32_PLUS
             }
             caps.OpenGL30 -> {
                 GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MAJOR, 3)
                 GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, 0)
                 GLFW.glfwWindowHint(GLFW.GLFW_OPENGL_PROFILE, GLFW.GLFW_OPENGL_CORE_PROFILE)
                 GLFW.glfwWindowHint(GLFW.GLFW_OPENGL_FORWARD_COMPAT, GL30.GL_TRUE)
-                graphics._glVersion = GLVersion.GL_30
             }
             caps.OpenGL21 -> {
                 GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MAJOR, 2)
                 GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, 1)
-                graphics._glVersion = GLVersion.GL_20
             }
         }
 

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
@@ -84,7 +84,6 @@ class LwjglContext(override val configuration: JvmConfiguration) : Context() {
 
         GLFW.glfwDestroyWindow(temp)
 
-
         // Configure GLFW
         GLFW.glfwDefaultWindowHints() // optional, the current window hints are already the default
 

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGL.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGL.kt
@@ -18,7 +18,7 @@ import java.nio.ByteBuffer as NioByteBuffer
  * @date 9/28/2021
  */
 class LwjglGL(private val engineStats: EngineStats) : GL {
-    internal var glVersion: GLVersion = GLVersion()
+    internal var glVersion: GLVersion = GLVersion(Context.Platform.DESKTOP)
     override val version: GLVersion get() = glVersion
 
     var lastBoundBuffer: GlBuffer? = null

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGL.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGL.kt
@@ -18,9 +18,8 @@ import java.nio.ByteBuffer as NioByteBuffer
  * @date 9/28/2021
  */
 class LwjglGL(private val engineStats: EngineStats) : GL {
-    internal var _glVersion: GLVersion = GLVersion.GL_30
-
-    override fun getGLVersion(): GLVersion = _glVersion
+    internal var glVersion: GLVersion = GLVersion()
+    override val version: GLVersion get() = glVersion
 
     var lastBoundBuffer: GlBuffer? = null
 
@@ -311,15 +310,11 @@ class LwjglGL(private val engineStats: EngineStats) : GL {
     }
 
     override fun frameBufferRenderBuffer(
-        attachementType: FrameBufferRenderBufferAttachment,
-        glRenderBuffer: GlRenderBuffer
+        attachementType: FrameBufferRenderBufferAttachment, glRenderBuffer: GlRenderBuffer
     ) {
         engineStats.calls++
         EXTFramebufferObject.glFramebufferRenderbufferEXT(
-            GL.FRAMEBUFFER,
-            attachementType.glFlag,
-            GL.RENDERBUFFER,
-            glRenderBuffer.reference
+            GL.FRAMEBUFFER, attachementType.glFlag, GL.RENDERBUFFER, glRenderBuffer.reference
         )
     }
 
@@ -334,17 +329,11 @@ class LwjglGL(private val engineStats: EngineStats) : GL {
     }
 
     override fun frameBufferTexture2D(
-        attachementType: FrameBufferRenderBufferAttachment,
-        glTexture: GlTexture,
-        level: Int
+        attachementType: FrameBufferRenderBufferAttachment, glTexture: GlTexture, level: Int
     ) {
         engineStats.calls++
         EXTFramebufferObject.glFramebufferTexture2DEXT(
-            GL.FRAMEBUFFER,
-            attachementType.glFlag,
-            GL.TEXTURE_2D,
-            glTexture.reference,
-            level
+            GL.FRAMEBUFFER, attachementType.glFlag, GL.TEXTURE_2D, glTexture.reference, level
         )
     }
 
@@ -633,14 +622,7 @@ class LwjglGL(private val engineStats: EngineStats) : GL {
     }
 
     override fun copyTexImage2D(
-        target: Int,
-        level: Int,
-        internalFormat: Int,
-        x: Int,
-        y: Int,
-        width: Int,
-        height: Int,
-        border: Int
+        target: Int, level: Int, internalFormat: Int, x: Int, y: Int, width: Int, height: Int, border: Int
     ) {
         engineStats.calls++
         glCopyTexImage2D(target, level, internalFormat, x, y, width, height, border)
@@ -677,24 +659,10 @@ class LwjglGL(private val engineStats: EngineStats) : GL {
     }
 
     override fun texImage2D(
-        target: Int,
-        level: Int,
-        internalFormat: Int,
-        format: Int,
-        width: Int,
-        height: Int,
-        type: Int
+        target: Int, level: Int, internalFormat: Int, format: Int, width: Int, height: Int, type: Int
     ) {
         glTexImage2D(
-            target,
-            level,
-            internalFormat,
-            width,
-            height,
-            0,
-            format,
-            type,
-            null as NioByteBuffer?
+            target, level, internalFormat, width, height, 0, format, type, null as NioByteBuffer?
         )
     }
 
@@ -713,15 +681,7 @@ class LwjglGL(private val engineStats: EngineStats) : GL {
         val pos = source.position
         source.position = 0
         glTexImage2D(
-            target,
-            level,
-            internalFormat,
-            width,
-            height,
-            0,
-            format,
-            type,
-            source.buffer
+            target, level, internalFormat, width, height, 0, format, type, source.buffer
         )
         source.position = pos
 

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGraphics.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGraphics.kt
@@ -21,8 +21,6 @@ class LwjglGraphics(val context: LwjglContext, engineStats: EngineStats) : Graph
         get() = _width
     override val height: Int
         get() = _height
-    override val glVersion: GLVersion
-        get() = gl.version
 
     override fun supportsExtension(extension: String): Boolean {
         return GLFW.glfwExtensionSupported(extension)

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGraphics.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGraphics.kt
@@ -1,7 +1,6 @@
 package com.lehaine.littlekt
 
 import com.lehaine.littlekt.graphics.Cursor
-import com.lehaine.littlekt.graphics.GL
 import com.lehaine.littlekt.graphics.GLVersion
 import com.lehaine.littlekt.graphics.SystemCursor
 import org.lwjgl.glfw.GLFW
@@ -13,13 +12,7 @@ import org.lwjgl.glfw.GLFW
 class LwjglGraphics(val context: LwjglContext, engineStats: EngineStats) : Graphics {
     private val systemCursors = mutableMapOf<SystemCursor, Long>()
 
-    override val gl: GL = LwjglGL(engineStats)
-
-    internal var _glVersion: GLVersion = GLVersion.GL_30
-        set(value) {
-            (gl as LwjglGL)._glVersion = value
-            field = value
-        }
+    override val gl: LwjglGL = LwjglGL(engineStats)
 
     internal var _width: Int = 0
     internal var _height: Int = 0
@@ -29,7 +22,7 @@ class LwjglGraphics(val context: LwjglContext, engineStats: EngineStats) : Graph
     override val height: Int
         get() = _height
     override val glVersion: GLVersion
-        get() = _glVersion
+        get() = gl.version
 
     override fun supportsExtension(extension: String): Boolean {
         return GLFW.glfwExtensionSupported(extension)


### PR DESCRIPTION
* Refactor `GLVersion` to own class and clean up handling of GL30 and WebGL checks
* Update WebGL and WebGL2 to use VAOs
* Closes #8 