### PR TITLE
Add a MutableTextureAtlas for packing textures into a TextureAtlas

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:atomicfu:$atomicFuVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion")
+                implementation(project(":tools"))
             }
         }
         val commonTest by getting {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureAtlas.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureAtlas.kt
@@ -55,5 +55,9 @@ class TextureAtlas internal constructor(private val textures: Map<String, Textur
             }
         }
         val name get() = frame.name
+
+        override fun toString(): String {
+            return "Entry(texture=$texture, slice=$slice, name='$name', frame='$frame')"
+        }
     }
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureAtlas.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureAtlas.kt
@@ -1,5 +1,6 @@
 package com.lehaine.littlekt.graphics
 
+import com.lehaine.littlekt.Disposable
 import com.lehaine.littlekt.file.atlas.AtlasInfo
 import com.lehaine.littlekt.file.atlas.AtlasPage
 import com.lehaine.littlekt.math.Rect
@@ -10,7 +11,7 @@ import com.lehaine.littlekt.util.internal.compareName
  * @author Colton Daily
  * @date 11/27/2021
  */
-class TextureAtlas internal constructor(private val textures: Map<String, Texture>, info: AtlasInfo) {
+class TextureAtlas internal constructor(private val textures: Map<String, Texture>, info: AtlasInfo) : Disposable {
     constructor(textures: Map<String, Texture>) : this(textures, AtlasInfo(AtlasPage.Meta(), listOf()))
 
     /**
@@ -59,5 +60,9 @@ class TextureAtlas internal constructor(private val textures: Map<String, Textur
         override fun toString(): String {
             return "Entry(texture=$texture, slice=$slice, name='$name', frame='$frame')"
         }
+    }
+
+    override fun dispose() {
+        textures.values.forEach { it.dispose() }
     }
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/util/MutableTextureAtlas.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/util/MutableTextureAtlas.kt
@@ -75,6 +75,9 @@ class MutableTextureAtlas(val context: Context, options: PackingOptions) {
 
 /**
  * Combine a [TextureSlice] with a [TextureAtlas] into a new [TextureAtlas].
+ *
+ * **This does not dispose of the [TextureAtlas] or the [Texture]!!**
+ *
  * @param slice the texture slice to combine
  * @param name the name to give the texture slice in the [TextureAtlas]
  * @param context the current [Context]
@@ -87,6 +90,9 @@ fun TextureAtlas.combine(slice: TextureSlice, name: String, context: Context) =
 
 /**
  * Combine a [Texture] with a [TextureAtlas] into a new [TextureAtlas].
+ *
+ * **This does not dispose of the [TextureAtlas] or the [Texture]!!**
+ *
  * @param texture the texture to combine
  * @param name the name to give the texture in the [TextureAtlas]
  * @param context the current [Context]
@@ -95,6 +101,9 @@ fun TextureAtlas.combine(texture: Texture, name: String, context: Context) = com
 
 /**
  * Combine another [TextureAtlas] with the current atlas to create a new [TextureAtlas].
+ *
+ * **This does not dispose of either [TextureAtlas]!!**
+ *
  * @param atlas the texture atlas to combine
  * @param context the current [Context]
  */

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/util/MutableTextureAtlas.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/util/MutableTextureAtlas.kt
@@ -1,0 +1,105 @@
+package com.lehaine.littlekt.util
+
+import com.lehaine.littlekt.Context
+import com.lehaine.littlekt.file.atlas.AtlasInfo
+import com.lehaine.littlekt.file.atlas.AtlasPage
+import com.lehaine.littlekt.graphics.*
+import com.lehaine.littlekt.graphics.gl.PixmapTextureData
+import com.lehaine.littlekt.tools.texturepacker.MaxRectsPacker
+import com.lehaine.littlekt.tools.texturepacker.PackingOptions
+import com.lehaine.littlekt.tools.texturepacker.Rect
+
+/**
+ * Allows building of a [TextureAtlas] by combining existing textures, texture slices, and texture atlases.
+ * @author Colton Daily
+ * @date 2/8/2022
+ */
+class MutableTextureAtlas(val context: Context, options: PackingOptions) {
+    constructor(context: Context, width: Int = 4096, height: Int = 4096, padding: Int = 2) : this(
+        context,
+        PackingOptions().apply {
+            maxWidth = width
+            maxHeight = height
+            paddingVertical = padding
+            paddingHorizontal = padding
+        })
+
+    private val packer = MaxRectsPacker(options)
+    private val entries = mutableListOf<Entry>()
+
+    private data class Entry(val slice: TextureSlice, val name: String) : Rect(0, 0, slice.width, slice.height)
+
+    val size get() = entries.size
+    val width get() = packer.width
+    val height get() = packer.height
+
+
+    fun add(slice: TextureSlice, name: String = "slice$size") {
+        entries += Entry(slice, name)
+    }
+
+    fun add(atlas: TextureAtlas) {
+        atlas.entries.forEach {
+            entries += Entry(it.slice, it.name)
+        }
+    }
+
+    fun toImmutable(useMiMaps: Boolean = true): TextureAtlas {
+        packer.add(entries)
+        val pages = mutableListOf<AtlasPage>()
+        val textures = mutableMapOf<String, Texture>()
+        packer.bins.forEachIndexed { index, bin ->
+            val textureName = "texture_$index"
+            val meta = AtlasPage.Meta(image = textureName)
+            val pixmap = Pixmap(bin.width, bin.height)
+            val frames = mutableListOf<AtlasPage.Frame>()
+            bin.rects.forEach {
+                it as Entry
+                val slice = it.slice
+                pixmap.drawSlice(it.x, it.y, slice)
+                frames += AtlasPage.Frame(
+                    it.name,
+                    AtlasPage.Rect(it.x, it.y, it.width, it.height),
+                    it.isRotated,
+                    slice.offsetX != 0 || slice.offsetY != 0 || slice.packedWidth != slice.width || slice.packedHeight != slice.height,
+                    AtlasPage.Rect(slice.offsetX, slice.offsetY, slice.packedWidth, slice.packedHeight),
+                    AtlasPage.Size(slice.originalWidth, slice.originalHeight)
+                )
+            }
+            pages += AtlasPage(meta, frames = frames)
+            textures["texture_$index"] = Texture(PixmapTextureData(pixmap, useMiMaps)).also { it.prepare(context) }
+        }
+        return TextureAtlas(textures, AtlasInfo(AtlasPage.Meta(), pages))
+    }
+}
+
+/**
+ * Combine a [TextureSlice] with a [TextureAtlas] into a new [TextureAtlas].
+ * @param slice the texture slice to combine
+ * @param name the name to give the texture slice in the [TextureAtlas]
+ * @param context the current [Context]
+ */
+fun TextureAtlas.combine(slice: TextureSlice, name: String, context: Context) =
+    MutableTextureAtlas(context).apply {
+        add(slice, name)
+        add(this@combine)
+    }.toImmutable()
+
+/**
+ * Combine a [Texture] with a [TextureAtlas] into a new [TextureAtlas].
+ * @param texture the texture to combine
+ * @param name the name to give the texture in the [TextureAtlas]
+ * @param context the current [Context]
+ */
+fun TextureAtlas.combine(texture: Texture, name: String, context: Context) = combine(texture.slice(), name, context)
+
+/**
+ * Combine another [TextureAtlas] with the current atlas to create a new [TextureAtlas].
+ * @param atlas the texture atlas to combine
+ * @param context the current [Context]
+ */
+fun TextureAtlas.combine(atlas: TextureAtlas, context: Context) =
+    MutableTextureAtlas(context).apply {
+        add(atlas)
+        add(this@combine)
+    }.toImmutable()

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/MutableAtlasTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/MutableAtlasTest.kt
@@ -1,0 +1,56 @@
+package com.lehaine.littlekt.samples
+
+import com.lehaine.littlekt.Context
+import com.lehaine.littlekt.ContextListener
+import com.lehaine.littlekt.file.vfs.readAtlas
+import com.lehaine.littlekt.file.vfs.readTexture
+import com.lehaine.littlekt.graphics.*
+import com.lehaine.littlekt.input.Key
+import com.lehaine.littlekt.util.combine
+import com.lehaine.littlekt.util.viewport.ScreenViewport
+
+/**
+ * @author Colton Daily
+ * @date 2/8/2022
+ */
+class MutableAtlasTest(context: Context) : ContextListener(context) {
+
+    override suspend fun Context.start() {
+        val fntTexture = resourcesVfs["m5x7_16_0.png"].readTexture()
+        val atlas = resourcesVfs["tiles.atlas.json"].readAtlas().combine(fntTexture, "font", this)
+        val bossAttackAnim = atlas.getAnimation("bossAttack")
+        val boss = AnimatedSprite(bossAttackAnim.firstFrame).apply {
+            x = 450f
+            y = 250f
+            scaleX = 2f
+            scaleY = 2f
+            playLooped(bossAttackAnim)
+        }
+
+        val camera = OrthographicCamera(graphics.width, graphics.height).apply {
+            viewport = ScreenViewport(graphics.width, graphics.height)
+        }
+        val batch = SpriteBatch(this)
+
+        onResize { width, height ->
+            camera.update(width, height, context)
+        }
+        onRender { dt ->
+            gl.clearColor(Color.DARK_GRAY)
+            camera.update()
+            boss.update(dt)
+            batch.use(camera.viewProjection) {
+                it.draw(atlas["font"].slice, 5f, 5f)
+                boss.render(it)
+            }
+
+            if (input.isKeyJustPressed(Key.P)) {
+                logger.info { stats }
+            }
+
+            if (input.isKeyJustPressed(Key.ESCAPE)) {
+                close()
+            }
+        }
+    }
+}

--- a/samples/src/jvmMain/kotlin/com/lehaine/littlekt/samples/MutableAtlasTest.kt
+++ b/samples/src/jvmMain/kotlin/com/lehaine/littlekt/samples/MutableAtlasTest.kt
@@ -1,0 +1,18 @@
+package com.lehaine.littlekt.samples
+
+import com.lehaine.littlekt.createLittleKtApp
+
+/**
+ * @author Colton Daily
+ * @date 2/8/2022
+ */
+fun main(args: Array<String>) {
+    createLittleKtApp {
+        width = 960
+        height = 540
+        vSync = true
+        title = "JVM - Mutable Atlas Test"
+    }.start {
+        MutableAtlasTest(it)
+    }
+}


### PR DESCRIPTION
Allows building a `TextureAtlas` at run time by combining separate textures and existing `TextureAtlas` objects into a single newly created `TextureAtlas`.

Adds a few extensions to `TextureAtlas` called `combine` that takes in either a `Texture`, `TextureSlice` or a `TextureAtlas`.