### PR TITLE
bitmap font: update loader to handle passing in existing texture slices

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:atomicfu:$atomicFuVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion")
-                implementation(project(":tools"))
+                api(project(":tools"))
             }
         }
         val commonTest by getting {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/AssetProvider.kt
@@ -7,6 +7,7 @@ import com.lehaine.littlekt.file.vfs.*
 import com.lehaine.littlekt.graphics.Pixmap
 import com.lehaine.littlekt.graphics.Texture
 import com.lehaine.littlekt.graphics.TextureAtlas
+import com.lehaine.littlekt.graphics.TextureSlice
 import com.lehaine.littlekt.graphics.font.BitmapFont
 import com.lehaine.littlekt.graphics.font.CharacterSets
 import com.lehaine.littlekt.graphics.font.TtfFont
@@ -164,7 +165,7 @@ open class AssetProvider(val context: Context) {
             },
             BitmapFont::class to { file, params ->
                 if (params is BitmapFontAssetParameter) {
-                    file.readBitmapFont(params.magFilter, params.mipmaps)
+                    file.readBitmapFont(params.magFilter, params.mipmaps, params.preloadedTextures)
                 } else {
                     file.readBitmapFont()
                 }
@@ -247,5 +248,6 @@ class BitmapFontAssetParameter(
     /**
      * Use mipmaps on the bitmap textures or not.
      */
-    val mipmaps: Boolean = true
+    val mipmaps: Boolean = true,
+    val preloadedTextures: List<TextureSlice> = listOf(),
 ) : GameAssetParameters

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/file/vfs/VfsLoaders.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/file/vfs/VfsLoaders.kt
@@ -61,12 +61,27 @@ suspend fun VfsFile.readTtfFont(chars: String = CharacterSets.LATIN_ALL): TtfFon
 
 /**
  * Reads a bitmap font.
+ * @param filter the filter to assign any [Texture] that gets loaded
+ * @param mipmaps whether the loaded [Texture] should use mipmaps
+ * @param preloadedTextures instead of loading a [Texture] when parsing the bitmap font, this will use an existing
+ * [TextureSlice]. This is useful if the bitmap font texture already exists in an atlas. Each slice in the list
+ * is considered a page in the bitmap font.
  */
-suspend fun VfsFile.readBitmapFont(filter: TexMagFilter = TexMagFilter.NEAREST, mipmaps: Boolean = true): BitmapFont {
+suspend fun VfsFile.readBitmapFont(
+    filter: TexMagFilter = TexMagFilter.NEAREST,
+    mipmaps: Boolean = true,
+    preloadedTextures: List<TextureSlice> = listOf(),
+): BitmapFont {
     val data = readString()
     val textures = mutableMapOf<Int, Texture>()
+    var pages = 0
+    preloadedTextures.forEach { slice ->
+        if (!textures.containsValue(slice.texture)) {
+            textures[pages++] = slice.texture
+        }
+    }
     if (data.startsWith("info")) {
-        return readBitmapFontTxt(data, this, textures, filter, mipmaps)
+        return readBitmapFontTxt(data, this, textures, preloadedTextures, preloadedTextures.isEmpty(), filter, mipmaps)
     } else {
         TODO("Unsupported font type.")
     }
@@ -76,6 +91,8 @@ private suspend fun readBitmapFontTxt(
     data: String,
     fontFile: VfsFile,
     textures: MutableMap<Int, Texture>,
+    preloadedTextures: List<TextureSlice>,
+    loadTextures: Boolean,
     filter: TexMagFilter,
     mipmaps: Boolean
 ): BitmapFont {
@@ -120,7 +137,9 @@ private suspend fun readBitmapFontTxt(
             line.startsWith("page") -> {
                 val id = map["id"]?.toInt() ?: 0
                 val file = map["file"]?.unquote() ?: error("Page without file")
-                textures[id] = fontFile.parent[file].readTexture(magFilter = filter, mipmaps = mipmaps)
+                if (loadTextures) {
+                    textures[id] = fontFile.parent[file].readTexture(magFilter = filter, mipmaps = mipmaps)
+                }
             }
             line.startsWith("common ") -> {
                 lineHeight = map["lineHeight"]?.toFloatOrNull() ?: 16f
@@ -142,16 +161,33 @@ private suspend fun readBitmapFontTxt(
                         capHeight = max(capHeight, height)
                     }
                 }
+                val slice = when {
+                    loadTextures -> {
+                        TextureSlice(
+                            texture,
+                            map["x"]?.toIntOrNull() ?: 0,
+                            map["y"]?.toIntOrNull() ?: 0,
+                            width,
+                            height
+                        )
+                    }
+                    preloadedTextures.isNotEmpty() -> {
+                        TextureSlice(
+                            preloadedTextures[page],
+                            map["x"]?.toIntOrNull() ?: 0,
+                            map["y"]?.toIntOrNull() ?: 0,
+                            width,
+                            height
+                        )
+                    }
+                    else -> {
+                        throw IllegalStateException("Unable to load any textures for ${fontFile.baseName}. If they are preloaded, make sure to pass that in 'readBitmapFont()'.")
+                    }
+                }
                 glyphs += BitmapFont.Glyph(
                     fontSize = fontSize,
                     id = id,
-                    slice = TextureSlice(
-                        texture,
-                        map["x"]?.toIntOrNull() ?: 0,
-                        map["y"]?.toIntOrNull() ?: 0,
-                        width,
-                        height
-                    ),
+                    slice = slice,
                     xoffset = map["xoffset"]?.toIntOrNull() ?: 0,
                     yoffset = map["yoffset"]?.toIntOrNull() ?: 0,
                     xadvance = map["xadvance"]?.toIntOrNull() ?: 0,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/util/MutableTextureAtlas.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/util/MutableTextureAtlas.kt
@@ -14,7 +14,7 @@ import com.lehaine.littlekt.tools.texturepacker.Rect
  * @author Colton Daily
  * @date 2/8/2022
  */
-class MutableTextureAtlas(val context: Context, options: PackingOptions) {
+class MutableTextureAtlas(val context: Context, options: PackingOptions = PackingOptions()) {
     constructor(context: Context, width: Int = 4096, height: Int = 4096, padding: Int = 2) : this(
         context,
         PackingOptions().apply {


### PR DESCRIPTION
* internal resources: combine UI atlas and default font texture into single atlas
* asset provider: update bitmap font asset parameters with new preloadedTextures list
* gradle: change tools project dependency to 'api' instead of 'implementation'
* closes #82 