### PR TITLE
Add texture array supported SpriteBatch

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
@@ -35,7 +35,7 @@ import kotlin.time.Duration
 inline fun sceneGraph(
     context: Context,
     viewport: Viewport = ScreenViewport(context.graphics.width, context.graphics.height),
-    batch: SpriteBatch? = null,
+    batch: Batch? = null,
     callback: @SceneGraphDslMarker SceneGraph.() -> Unit = {}
 ): SceneGraph {
     contract { callsInPlace(callback, InvocationKind.EXACTLY_ONCE) }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
@@ -6,6 +6,7 @@ import com.lehaine.littlekt.graph.node.Node
 import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.InputEvent
 import com.lehaine.littlekt.graph.node.node2d.ui.Control
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.OrthographicCamera
 import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.graphics.use
@@ -52,11 +53,11 @@ inline fun sceneGraph(
 open class SceneGraph(
     val context: Context,
     val viewport: Viewport = ScreenViewport(context.graphics.width, context.graphics.height),
-    batch: SpriteBatch? = null,
+    batch: Batch? = null,
 ) : InputProcessor, Disposable {
 
     private var ownsBatch = true
-    val batch: SpriteBatch = batch?.also { ownsBatch = false } ?: SpriteBatch(context)
+    val batch: Batch = batch?.also { ownsBatch = false } ?: SpriteBatch(context)
 
     val root: Node by lazy {
         Node().apply {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
@@ -5,7 +5,6 @@ import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.internal.NodeList
 import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.util.*
 import com.lehaine.littlekt.util.viewport.Viewport
 import kotlin.native.concurrent.ThreadLocal
@@ -296,7 +295,7 @@ open class Node : Comparable<Node> {
     /**
      * Internal debug render method. Calls the [debugRender] method.
      */
-    private fun _debugRender(batch: SpriteBatch) {
+    private fun _debugRender(batch: Batch) {
         debugRender(batch)
         onDebugRender.emit(batch)
         nodes.forEach {
@@ -424,7 +423,7 @@ open class Node : Comparable<Node> {
     open fun onPostEnterScene() {}
 
     /**
-     * The main render method. The [Camera] can be used for culling and the [SpriteBatch] instance to draw with.
+     * The main render method. The [Camera] can be used for culling and the [Batch] instance to draw with.
      * @param batch the batcher
      * @param camera the Camera2D node
      */

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
@@ -3,6 +3,7 @@ package com.lehaine.littlekt.graph.node
 import com.lehaine.littlekt.graph.SceneGraph
 import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.internal.NodeList
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
 import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.util.*
@@ -188,7 +189,7 @@ open class Node : Comparable<Node> {
      * }
      * ```
      */
-    val onRender: DoubleSignal<SpriteBatch, Camera> = signal2v()
+    val onRender: DoubleSignal<Batch, Camera> = signal2v()
 
     /**
      * List of 'debugRender' callbacks called when [debugRender] is called. Add any additional callbacks directly to this list.
@@ -203,7 +204,7 @@ open class Node : Comparable<Node> {
      * }
      * ```
      */
-    val onDebugRender: SingleSignal<SpriteBatch> = signal1v()
+    val onDebugRender: SingleSignal<Batch> = signal1v()
 
     /**
      * List of 'update' callbacks called when [update] is called. Add any additional callbacks directly to this list.
@@ -284,7 +285,7 @@ open class Node : Comparable<Node> {
     /**
      * Internal rendering that needs to be done on the node that shouldn't be overridden. Calls [render] method.
      */
-    internal fun _render(batch: SpriteBatch, camera: Camera) {
+    internal fun _render(batch: Batch, camera: Camera) {
         render(batch, camera)
         onRender.emit(batch, camera)
         nodes.forEach {
@@ -427,13 +428,13 @@ open class Node : Comparable<Node> {
      * @param batch the batcher
      * @param camera the Camera2D node
      */
-    open fun render(batch: SpriteBatch, camera: Camera) {}
+    open fun render(batch: Batch, camera: Camera) {}
 
     /**
      * Draw any debug related items here.
      * @param batch the sprite batch to draw with
      */
-    open fun debugRender(batch: SpriteBatch) {}
+    open fun debugRender(batch: Batch) {}
 
     /**
      * Called when this [Node] is added to a [SceneGraph] after all pending [Node] changes are committed.

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/Drawable.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/Drawable.kt
@@ -1,5 +1,6 @@
 package com.lehaine.littlekt.graph.node.component
 
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Color
 import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.math.geom.Angle
@@ -22,7 +23,7 @@ interface Drawable {
 
 
     fun draw(
-        batch: SpriteBatch,
+        batch: Batch,
         x: Float,
         y: Float,
         width: Float,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/Drawable.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/Drawable.kt
@@ -2,7 +2,6 @@ package com.lehaine.littlekt.graph.node.component
 
 import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Color
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.math.geom.Angle
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/NinePatchDrawable.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/NinePatchDrawable.kt
@@ -1,8 +1,8 @@
 package com.lehaine.littlekt.graph.node.component
 
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Color
 import com.lehaine.littlekt.graphics.NinePatch
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.math.geom.Angle
 
 /**
@@ -21,7 +21,7 @@ class NinePatchDrawable(val ninePatch: NinePatch) : Drawable {
     override var modulate: Color = Color.WHITE
 
     override fun draw(
-        batch: SpriteBatch,
+        batch: Batch,
         x: Float,
         y: Float,
         width: Float,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/TextureSliceDrawable.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/TextureSliceDrawable.kt
@@ -22,7 +22,7 @@ class TextureSliceDrawable(val slice: TextureSlice) : Drawable {
     override var modulate: Color = Color.WHITE
 
     override fun draw(
-        batch: SpriteBatch,
+        batch: Batch,
         x: Float,
         y: Float,
         width: Float,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Button.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Button.kt
@@ -8,10 +8,7 @@ import com.lehaine.littlekt.graph.node.component.Drawable
 import com.lehaine.littlekt.graph.node.component.HAlign
 import com.lehaine.littlekt.graph.node.component.Theme
 import com.lehaine.littlekt.graph.node.component.VAlign
-import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.Color
-import com.lehaine.littlekt.graphics.MutableColor
-import com.lehaine.littlekt.graphics.SpriteBatch
+import com.lehaine.littlekt.graphics.*
 import com.lehaine.littlekt.graphics.font.BitmapFont
 import com.lehaine.littlekt.graphics.font.BitmapFontCache
 import com.lehaine.littlekt.graphics.font.GlyphLayout
@@ -170,7 +167,7 @@ open class Button : BaseButton() {
             onMinimumSizeChanged()
         }
 
-    override fun render(batch: SpriteBatch, camera: Camera) {
+    override fun render(batch: Batch, camera: Camera) {
 
         val drawable: Drawable
         when (drawMode) {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
@@ -9,7 +9,6 @@ import com.lehaine.littlekt.graph.node.component.AnchorLayout.*
 import com.lehaine.littlekt.graph.node.node2d.Node2D
 import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Color
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.graphics.font.BitmapFont
 import com.lehaine.littlekt.math.Mat4
 import com.lehaine.littlekt.math.Rect

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
@@ -7,6 +7,7 @@ import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.*
 import com.lehaine.littlekt.graph.node.component.AnchorLayout.*
 import com.lehaine.littlekt.graph.node.node2d.Node2D
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Color
 import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.graphics.font.BitmapFont
@@ -636,12 +637,12 @@ open class Control : Node2D() {
             AnchorSide.TOP -> _marginBottom = value
         }
 
-    protected fun applyTransform(batch: SpriteBatch) {
+    protected fun applyTransform(batch: Batch) {
         tempMat4.set(batch.transformMatrix)
         batch.transformMatrix = localToGlobalTransformMat4
     }
 
-    protected fun resetTransform(batch: SpriteBatch) {
+    protected fun resetTransform(batch: Batch) {
         batch.transformMatrix = tempMat4
     }
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Label.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Label.kt
@@ -7,10 +7,7 @@ import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.HAlign
 import com.lehaine.littlekt.graph.node.component.Theme
 import com.lehaine.littlekt.graph.node.component.VAlign
-import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.Color
-import com.lehaine.littlekt.graphics.MutableColor
-import com.lehaine.littlekt.graphics.SpriteBatch
+import com.lehaine.littlekt.graphics.*
 import com.lehaine.littlekt.graphics.font.BitmapFont
 import com.lehaine.littlekt.graphics.font.BitmapFontCache
 import com.lehaine.littlekt.graphics.font.GlyphLayout
@@ -156,7 +153,7 @@ open class Label : Control() {
             onMinimumSizeChanged()
         }
 
-    override fun render(batch: SpriteBatch, camera: Camera) {
+    override fun render(batch: Batch, camera: Camera) {
         cache.let {
             tempColor.set(color).mul(fontColor)
             it.tint(tempColor)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/NinePatchRect.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/NinePatchRect.kt
@@ -4,10 +4,7 @@ import com.lehaine.littlekt.graph.SceneGraph
 import com.lehaine.littlekt.graph.node.Node
 import com.lehaine.littlekt.graph.node.addTo
 import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
-import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.NinePatch
-import com.lehaine.littlekt.graphics.SpriteBatch
-import com.lehaine.littlekt.graphics.Textures
+import com.lehaine.littlekt.graphics.*
 
 /**
  * Adds a [NinePatchRect] to the current [Node] as a child and then triggers the [callback]
@@ -44,7 +41,7 @@ open class NinePatchRect : Control() {
         minSizeInvalid = false
     }
 
-    override fun render(batch: SpriteBatch, camera: Camera) {
+    override fun render(batch: Batch, camera: Camera) {
         ninePatch.draw(
             batch,
             globalX,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Panel.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Panel.kt
@@ -5,6 +5,7 @@ import com.lehaine.littlekt.graph.node.Node
 import com.lehaine.littlekt.graph.node.addTo
 import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.Drawable
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
 import com.lehaine.littlekt.graphics.SpriteBatch
 
@@ -42,7 +43,7 @@ open class Panel : Control() {
 
     private val panelThemeVar get() = if (mode == Mode.BACKGROUND) themeVars.panel else themeVars.panelForeground
 
-    override fun render(batch: SpriteBatch, camera: Camera) {
+    override fun render(batch: Batch, camera: Camera) {
         panel.let {
             it.draw(batch, globalX, globalY, width, height, scaleX, scaleY, rotation, it.modulate)
         }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Panel.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Panel.kt
@@ -7,7 +7,6 @@ import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.Drawable
 import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
 
 /**
  * Adds a [Panel] to the current [Node] as a child and then triggers the [callback]

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/PanelContainer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/PanelContainer.kt
@@ -5,8 +5,8 @@ import com.lehaine.littlekt.graph.node.Node
 import com.lehaine.littlekt.graph.node.addTo
 import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.Drawable
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
 
 /**
  * Adds a [PanelContainer] to the current [Node] as a child and then triggers the [callback]
@@ -41,7 +41,7 @@ open class PanelContainer : Container() {
             onMinimumSizeChanged()
         }
 
-    override fun render(batch: SpriteBatch, camera: Camera) {
+    override fun render(batch: Batch, camera: Camera) {
         panel.let {
             it.draw(batch, globalX, globalY, width, height, scaleX, scaleY, rotation, it.modulate)
         }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/ProgressBar.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/ProgressBar.kt
@@ -6,10 +6,10 @@ import com.lehaine.littlekt.graph.node.addTo
 import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.Drawable
 import com.lehaine.littlekt.graph.node.component.Theme
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
 import com.lehaine.littlekt.graphics.Color
 import com.lehaine.littlekt.graphics.MutableColor
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.graphics.font.BitmapFont
 import com.lehaine.littlekt.graphics.font.BitmapFontCache
 import com.lehaine.littlekt.graphics.font.GlyphLayout
@@ -83,7 +83,7 @@ open class ProgressBar : Range() {
     private var cache: BitmapFontCache = BitmapFontCache(font)
     private val layout = GlyphLayout()
 
-    override fun render(batch: SpriteBatch, camera: Camera) {
+    override fun render(batch: Batch, camera: Camera) {
         bg.draw(batch, globalX, globalY, width, height)
         val progress = ratio * (width - fg.minWidth)
         if (progress > 0) {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/TextureRect.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/TextureRect.kt
@@ -5,8 +5,8 @@ import com.lehaine.littlekt.graph.node.Node
 import com.lehaine.littlekt.graph.node.addTo
 import com.lehaine.littlekt.graph.node.annotation.SceneGraphDslMarker
 import com.lehaine.littlekt.graph.node.component.StretchMode
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.graphics.TextureSlice
 import kotlin.math.absoluteValue
 
@@ -65,7 +65,7 @@ open class TextureRect : Control() {
     override val membersAndPropertiesString: String
         get() = "${super.membersAndPropertiesString}, flipX=$flipX, flipY=$flipY, stretchMode=$stretchMode, expand=$expand, textureRegion=$slice"
 
-    override fun render(batch: SpriteBatch, camera: Camera) {
+    override fun render(batch: Batch, camera: Camera) {
         super.render(batch, camera)
         slice?.let {
             var newWidth = 0f

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/AnimatedSprite.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/AnimatedSprite.kt
@@ -21,7 +21,7 @@ class AnimatedSprite(
         }
     }
 
-    fun render(batch: SpriteBatch) {
+    fun render(batch: Batch) {
         batch.draw(slice, x, y, slice.width * anchorX, slice.height * anchorY, scaleX = scaleX, scaleY = scaleY)
     }
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Batch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Batch.kt
@@ -36,6 +36,24 @@ interface Batch : Disposable {
         colorBits: Float = this.colorBits,
         flipX: Boolean = false,
         flipY: Boolean = false,
+    ) = draw(
+        texture,
+        x,
+        y,
+        originX,
+        originY,
+        width,
+        height,
+        scaleX,
+        scaleY,
+        rotation,
+        0,
+        0,
+        texture.width,
+        texture.height,
+        colorBits,
+        flipX,
+        flipY
     )
 
     fun draw(

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Batch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Batch.kt
@@ -1,0 +1,93 @@
+package com.lehaine.littlekt.graphics
+
+import com.lehaine.littlekt.graphics.gl.BlendFactor
+import com.lehaine.littlekt.math.Mat4
+import com.lehaine.littlekt.math.geom.Angle
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * @author Colton Daily
+ * @date 2/8/2022
+ */
+interface Batch {
+
+    fun begin(projectionMatrix: Mat4? = null)
+
+    fun draw(
+        texture: Texture,
+        x: Float,
+        y: Float,
+        originX: Float = 0f,
+        originY: Float = 0f,
+        width: Float = texture.width.toFloat(),
+        height: Float = texture.height.toFloat(),
+        scaleX: Float = 1f,
+        scaleY: Float = 1f,
+        rotation: Angle = Angle.ZERO,
+        colorBits: Float = Color.WHITE.toFloatBits(),
+        flipX: Boolean = false,
+        flipY: Boolean = false,
+    )
+
+    fun draw(
+        slice: TextureSlice,
+        x: Float,
+        y: Float,
+        originX: Float = 0f,
+        originY: Float = 0f,
+        width: Float = slice.width.toFloat(),
+        height: Float = slice.height.toFloat(),
+        scaleX: Float = 1f,
+        scaleY: Float = 1f,
+        rotation: Angle = Angle.ZERO,
+        colorBits: Float = Color.WHITE.toFloatBits(),
+        flipX: Boolean = false,
+        flipY: Boolean = false,
+    )
+
+    fun draw(
+        texture: Texture,
+        x: Float,
+        y: Float,
+        originX: Float = 0f,
+        originY: Float = 0f,
+        width: Float = texture.width.toFloat(),
+        height: Float = texture.height.toFloat(),
+        scaleX: Float = 1f,
+        scaleY: Float = 1f,
+        rotation: Angle = Angle.ZERO,
+        srcX: Int = 0,
+        srcY: Int = 0,
+        srcWidth: Int = texture.width,
+        srcHeight: Int = texture.height,
+        colorBits: Float = Color.WHITE.toFloatBits(),
+        flipX: Boolean = false,
+        flipY: Boolean = false,
+    )
+
+    fun draw(texture: Texture, spriteVertices: FloatArray, offset: Int = 0, count: Int = spriteVertices.size)
+    fun end()
+    fun flush()
+
+    fun setBlendFunction(src: BlendFactor, dst: BlendFactor)
+    fun setBlendFunctionSeparate(
+        srcFuncColor: BlendFactor,
+        dstFuncColor: BlendFactor,
+        srcFuncAlpha: BlendFactor,
+        dstFuncAlpha: BlendFactor
+    )
+
+    fun setToPreviousBlendFunction()
+
+    fun useDefaultShader()
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <T : Batch> T.use(projectionMatrix: Mat4? = null, action: (T) -> Unit) {
+    contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
+    begin(projectionMatrix)
+    action(this)
+    end()
+}

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Batch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Batch.kt
@@ -1,6 +1,8 @@
 package com.lehaine.littlekt.graphics
 
+import com.lehaine.littlekt.Disposable
 import com.lehaine.littlekt.graphics.gl.BlendFactor
+import com.lehaine.littlekt.graphics.shader.ShaderProgram
 import com.lehaine.littlekt.math.Mat4
 import com.lehaine.littlekt.math.geom.Angle
 import kotlin.contracts.ExperimentalContracts
@@ -11,7 +13,12 @@ import kotlin.contracts.contract
  * @author Colton Daily
  * @date 2/8/2022
  */
-interface Batch {
+interface Batch : Disposable {
+    var color: Color
+    var colorBits: Float
+    var transformMatrix: Mat4
+    var projectionMatrix: Mat4
+    var shader: ShaderProgram<*, *>
 
     fun begin(projectionMatrix: Mat4? = null)
 
@@ -26,7 +33,7 @@ interface Batch {
         scaleX: Float = 1f,
         scaleY: Float = 1f,
         rotation: Angle = Angle.ZERO,
-        colorBits: Float = Color.WHITE.toFloatBits(),
+        colorBits: Float = this.colorBits,
         flipX: Boolean = false,
         flipY: Boolean = false,
     )
@@ -42,7 +49,7 @@ interface Batch {
         scaleX: Float = 1f,
         scaleY: Float = 1f,
         rotation: Angle = Angle.ZERO,
-        colorBits: Float = Color.WHITE.toFloatBits(),
+        colorBits: Float = this.colorBits,
         flipX: Boolean = false,
         flipY: Boolean = false,
     )
@@ -62,7 +69,7 @@ interface Batch {
         srcY: Int = 0,
         srcWidth: Int = texture.width,
         srcHeight: Int = texture.height,
-        colorBits: Float = Color.WHITE.toFloatBits(),
+        colorBits: Float = this.colorBits,
         flipX: Boolean = false,
         flipY: Boolean = false,
     )

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
@@ -158,6 +158,15 @@ interface GL {
     fun deleteFrameBuffer(glFrameBuffer: GlFrameBuffer)
     fun deleteRenderBuffer(glRenderBuffer: GlRenderBuffer)
     fun frameBufferTexture2D(attachementType: FrameBufferRenderBufferAttachment, glTexture: GlTexture, level: Int)
+    fun frameBufferTexture2D(
+        target: Int,
+        attachementType: FrameBufferRenderBufferAttachment,
+        glTexture: GlTexture,
+        level: Int
+    )
+
+    fun readBuffer(mode: Int)
+
     fun checkFrameBufferStatus(): FrameBufferStatus
 
     fun createBuffer(): GlBuffer
@@ -224,6 +233,7 @@ interface GL {
     fun activeTexture(texture: Int)
     fun bindTexture(target: Int, glTexture: GlTexture)
     fun bindTexture(target: TextureTarget, glTexture: GlTexture) = bindTexture(target.glFlag, glTexture)
+    fun bindDefaultTexture(target: TextureTarget)
     fun deleteTexture(glTexture: GlTexture)
 
     fun compressedTexImage2D(
@@ -317,7 +327,6 @@ interface GL {
         height: Int,
     ) = copyTexSubImage2D(target.glFlag, level, xOffset, yOffset, x, y, width, height)
 
-
     fun texSubImage2D(
         target: Int,
         level: Int,
@@ -383,6 +392,183 @@ interface GL {
         type: DataType,
         source: ByteBuffer
     ) = texImage2D(target.glFlag, level, internalFormat.glFlag, format.glFlag, width, height, type.glFlag, source)
+
+
+    fun compressedTexImage3D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        width: Int,
+        height: Int,
+        depth:Int,
+        source: ByteBuffer?
+    )
+
+    fun compressedTexImage3D(
+        target: TextureTarget,
+        level: Int,
+        internalFormat: TextureFormat,
+        width: Int,
+        height: Int,
+        depth:Int,
+        source: ByteBuffer?
+    ) = compressedTexImage3D(
+        target.glFlag,
+        level,
+        internalFormat.glFlag,
+        width,
+        height,
+        depth,
+        source
+    )
+
+    fun compressedTexSubImage3D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        width: Int,
+        height: Int,
+        depth:Int,
+        format: Int,
+        source: ByteBuffer
+    )
+
+    fun compressedTexSubImage3D(
+        target: TextureTarget,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        width: Int,
+        height: Int,
+        depth:Int,
+        format: TextureFormat,
+        source: ByteBuffer
+    ) = compressedTexSubImage3D(target.glFlag, level, xOffset, yOffset, zOffset, width, height, depth, format.glFlag, source)
+
+    fun copyTexSubImage3D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    )
+
+    fun copyTexSubImage3D(
+        target: TextureTarget,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) = copyTexSubImage3D(target.glFlag, level, xOffset, yOffset, zOffset, x, y, width, height)
+
+
+    fun texSubImage3D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        width: Int,
+        height: Int,
+        depth:Int,
+        format: Int,
+        type: Int,
+        source: ByteBuffer
+    )
+
+    fun texSubImage3D(
+        target: TextureTarget,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        width: Int,
+        height: Int,
+        depth:Int,
+        format: TextureFormat,
+        type: DataType,
+        source: ByteBuffer
+    ) = texSubImage3D(
+        target.glFlag,
+        level,
+        xOffset,
+        yOffset,
+        zOffset,
+        width,
+        height,
+        depth,
+        format.glFlag,
+        type.glFlag,
+        source
+    )
+
+    fun texImage3D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        format: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        type: Int
+    )
+
+    fun texImage3D(
+        target: TextureTarget,
+        level: Int,
+        internalFormat: TextureFormat,
+        format: TextureFormat,
+        width: Int,
+        height: Int,
+        depth: Int,
+        type: DataType
+    ) = texImage3D(target.glFlag, level, internalFormat.glFlag, format.glFlag, width, height, depth, type.glFlag)
+
+    fun texImage3D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        format: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        type: Int,
+        source: ByteBuffer
+    )
+
+    fun texImage3D(
+        target: TextureTarget,
+        level: Int,
+        internalFormat: TextureFormat,
+        format: TextureFormat,
+        width: Int,
+        height: Int,
+        depth: Int,
+        type: DataType,
+        source: ByteBuffer
+    ) = texImage3D(
+        target.glFlag,
+        level,
+        internalFormat.glFlag,
+        format.glFlag,
+        width,
+        height,
+        depth,
+        type.glFlag,
+        source
+    )
+
 
     fun texParameteri(target: Int, pname: Int, param: Int)
     fun texParameteri(target: TextureTarget, paramName: TexParameter, paramValue: Int) =

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/NinePatch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/NinePatch.kt
@@ -96,7 +96,7 @@ class NinePatch(private val slice: TextureSlice, val left: Int, val right: Int, 
     }
 
     fun draw(
-        batch: SpriteBatch,
+        batch: Batch,
         x: Float,
         y: Float,
         width: Float,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Particle.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/Particle.kt
@@ -117,7 +117,7 @@ class Particle(var slice: TextureSlice) {
 }
 
 
-fun Particle.draw(batch: SpriteBatch) {
+fun Particle.draw(batch: Batch) {
     if (!visible || !alive) return
 
     batch.draw(

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/ParticleSimulator.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/ParticleSimulator.kt
@@ -195,7 +195,7 @@ class ParticleSimulator(maxParticles: Int) {
     }
 }
 
-fun ParticleSimulator.draw(batch: SpriteBatch) {
+fun ParticleSimulator.draw(batch: Batch) {
     for (i in 0..numAlloc) {
         particles[i].draw(batch)
     }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/SpriteBatch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/SpriteBatch.kt
@@ -1,7 +1,6 @@
 package com.lehaine.littlekt.graphics
 
 import com.lehaine.littlekt.Context
-import com.lehaine.littlekt.Disposable
 import com.lehaine.littlekt.graphics.gl.BlendFactor
 import com.lehaine.littlekt.graphics.gl.DrawMode
 import com.lehaine.littlekt.graphics.gl.State
@@ -12,9 +11,6 @@ import com.lehaine.littlekt.math.Mat4
 import com.lehaine.littlekt.math.geom.Angle
 import com.lehaine.littlekt.math.geom.cosine
 import com.lehaine.littlekt.math.geom.sine
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 import kotlin.math.min
 
 /**
@@ -24,7 +20,7 @@ import kotlin.math.min
 class SpriteBatch(
     val context: Context,
     val size: Int = 1000,
-) : Batch, Disposable {
+) : Batch {
     companion object {
         private const val VERTEX_SIZE = 2 + 1 + 2
         private const val SPRITE_SIZE = 4 * VERTEX_SIZE
@@ -32,7 +28,7 @@ class SpriteBatch(
 
     private val gl get() = context.graphics.gl
     val defaultShader = ShaderProgram(DefaultVertexShader(), DefaultFragmentShader()).also { it.prepare(context) }
-    var shader: ShaderProgram<*, *> = defaultShader
+    override var shader: ShaderProgram<*, *> = defaultShader
         set(value) {
             if (drawing) {
                 flush()
@@ -51,7 +47,7 @@ class SpriteBatch(
         private set
 
     private var drawing = false
-    var transformMatrix = Mat4()
+    override var transformMatrix = Mat4()
         set(value) {
             if (drawing) {
                 flush()
@@ -61,7 +57,7 @@ class SpriteBatch(
                 setupMatrices()
             }
         }
-    var projectionMatrix = Mat4().setToOrthographic(
+    override var projectionMatrix = Mat4().setToOrthographic(
         left = 0f,
         right = context.graphics.width.toFloat(),
         bottom = 0f,
@@ -92,13 +88,13 @@ class SpriteBatch(
     private var invTexWidth = 0f
     private var invTexHeight = 0f
 
-    var color = Color.WHITE
+    override var color = Color.WHITE
         set(value) {
             if (field == value) return
             field = value
             colorBits = field.toFloatBits()
         }
-    private var colorBits = color.toFloatBits()
+    override var colorBits = color.toFloatBits()
 
     private var prevBlendSrcFunc = BlendFactor.SRC_ALPHA
     private var prevBlendDstFunc = BlendFactor.ONE_MINUS_SRC_ALPHA

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/SpriteBatch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/SpriteBatch.kt
@@ -24,7 +24,7 @@ import kotlin.math.min
 class SpriteBatch(
     val context: Context,
     val size: Int = 1000,
-) : Disposable {
+) : Batch, Disposable {
     companion object {
         private const val VERTEX_SIZE = 2 + 1 + 2
         private const val SPRITE_SIZE = 4 * VERTEX_SIZE
@@ -109,7 +109,7 @@ class SpriteBatch(
     private var blendSrcFuncAlpha = prevBlendSrcFuncAlpha
     private var blendDstFuncAlpha = prevBlendDstFuncAlpha
 
-    fun begin(projectionMatrix: Mat4? = null) {
+    override fun begin(projectionMatrix: Mat4?) {
         if (drawing) {
             throw IllegalStateException("SpriteBatch.end must be called before begin.")
         }
@@ -126,20 +126,20 @@ class SpriteBatch(
         drawing = true
     }
 
-    fun draw(
+    override fun draw(
         texture: Texture,
         x: Float,
         y: Float,
-        originX: Float = 0f,
-        originY: Float = 0f,
-        width: Float = texture.width.toFloat(),
-        height: Float = texture.height.toFloat(),
-        scaleX: Float = 1f,
-        scaleY: Float = 1f,
-        rotation: Angle = Angle.ZERO,
-        colorBits: Float = this.colorBits,
-        flipX: Boolean = false,
-        flipY: Boolean = false,
+        originX: Float,
+        originY: Float,
+        width: Float,
+        height: Float,
+        scaleX: Float,
+        scaleY: Float,
+        rotation: Angle,
+        colorBits: Float,
+        flipX: Boolean,
+        flipY: Boolean,
     ) {
         if (!drawing) {
             throw IllegalStateException("SpriteBatch.begin must be called before draw.")
@@ -248,20 +248,20 @@ class SpriteBatch(
         idx += SPRITE_SIZE
     }
 
-    fun draw(
+    override fun draw(
         slice: TextureSlice,
         x: Float,
         y: Float,
-        originX: Float = 0f,
-        originY: Float = 0f,
-        width: Float = slice.width.toFloat(),
-        height: Float = slice.height.toFloat(),
-        scaleX: Float = 1f,
-        scaleY: Float = 1f,
-        rotation: Angle = Angle.ZERO,
-        colorBits: Float = this.colorBits,
-        flipX: Boolean = false,
-        flipY: Boolean = false,
+        originX: Float,
+        originY: Float,
+        width: Float,
+        height: Float,
+        scaleX: Float,
+        scaleY: Float,
+        rotation: Angle,
+        colorBits: Float,
+        flipX: Boolean,
+        flipY: Boolean,
     ) {
         if (!drawing) {
             throw IllegalStateException("SpriteBatch.begin must be called before draw.")
@@ -381,24 +381,24 @@ class SpriteBatch(
         idx += SPRITE_SIZE
     }
 
-    fun draw(
+    override fun draw(
         texture: Texture,
         x: Float,
         y: Float,
-        originX: Float = 0f,
-        originY: Float = 0f,
-        width: Float = texture.width.toFloat(),
-        height: Float = texture.height.toFloat(),
-        scaleX: Float = 1f,
-        scaleY: Float = 1f,
-        rotation: Angle = Angle.ZERO,
-        srcX: Int = 0,
-        srcY: Int = 0,
-        srcWidth: Int = texture.width,
-        srcHeight: Int = texture.height,
-        colorBits: Float = this.colorBits,
-        flipX: Boolean = false,
-        flipY: Boolean = false,
+        originX: Float,
+        originY: Float,
+        width: Float,
+        height: Float,
+        scaleX: Float,
+        scaleY: Float,
+        rotation: Angle,
+        srcX: Int,
+        srcY: Int,
+        srcWidth: Int,
+        srcHeight: Int,
+        colorBits: Float,
+        flipX: Boolean,
+        flipY: Boolean,
     ) {
         if (!drawing) {
             throw IllegalStateException("SpriteBatch.begin must be called before draw.")
@@ -528,7 +528,7 @@ class SpriteBatch(
         idx += SPRITE_SIZE
     }
 
-    fun draw(texture: Texture, spriteVertices: FloatArray, offset: Int = 0, count: Int = spriteVertices.size) {
+    override fun draw(texture: Texture, spriteVertices: FloatArray, offset: Int, count: Int) {
         if (!drawing) {
             throw IllegalStateException("SpriteBatch.begin must be called before draw.")
         }
@@ -561,7 +561,7 @@ class SpriteBatch(
         }
     }
 
-    fun end() {
+    override fun end() {
         if (!drawing) {
             throw IllegalStateException("SpriteBatch.begin must be called before end.")
         }
@@ -574,7 +574,7 @@ class SpriteBatch(
         gl.disable(State.BLEND)
     }
 
-    fun flush() {
+    override fun flush() {
         if (idx == 0) {
             return
         }
@@ -592,11 +592,11 @@ class SpriteBatch(
         idx = 0
     }
 
-    fun setBlendFunction(src: BlendFactor, dst: BlendFactor) {
+    override fun setBlendFunction(src: BlendFactor, dst: BlendFactor) {
         setBlendFunctionSeparate(src, dst, src, dst)
     }
 
-    fun setBlendFunctionSeparate(
+    override fun setBlendFunctionSeparate(
         srcFuncColor: BlendFactor,
         dstFuncColor: BlendFactor,
         srcFuncAlpha: BlendFactor,
@@ -618,7 +618,7 @@ class SpriteBatch(
         blendDstFuncAlpha = dstFuncAlpha
     }
 
-    fun setToPreviousBlendFunction() {
+    override fun setToPreviousBlendFunction() {
         if (blendSrcFunc == prevBlendSrcFunc && blendDstFunc == prevBlendDstFunc
             && blendSrcFuncAlpha == prevBlendSrcFuncAlpha && blendDstFuncAlpha == prevBlendDstFuncAlpha
         ) {
@@ -632,7 +632,7 @@ class SpriteBatch(
         blendDstFuncAlpha = prevBlendDstFuncAlpha
     }
 
-    fun useDefaultShader() {
+    override fun useDefaultShader() {
         if (shader != defaultShader) {
             shader = defaultShader
         }
@@ -655,12 +655,4 @@ class SpriteBatch(
         mesh.dispose()
         shader.dispose()
     }
-}
-
-@OptIn(ExperimentalContracts::class)
-inline fun SpriteBatch.use(projectionMatrix: Mat4? = null, action: (SpriteBatch) -> Unit) {
-    contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    begin(projectionMatrix)
-    action(this)
-    end()
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/SpriteBatch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/SpriteBatch.kt
@@ -123,128 +123,6 @@ class SpriteBatch(
     }
 
     override fun draw(
-        texture: Texture,
-        x: Float,
-        y: Float,
-        originX: Float,
-        originY: Float,
-        width: Float,
-        height: Float,
-        scaleX: Float,
-        scaleY: Float,
-        rotation: Angle,
-        colorBits: Float,
-        flipX: Boolean,
-        flipY: Boolean,
-    ) {
-        if (!drawing) {
-            throw IllegalStateException("SpriteBatch.begin must be called before draw.")
-        }
-        if (texture != lastTexture) {
-            switchTexture(texture)
-        } else if (idx == mesh.maxVertices) {
-            flush()
-        }
-
-        var fx = -originX
-        var fy = -originY
-        var fx2 = width - originX
-        var fy2 = height - originY
-
-        if (scaleX != 1f || scaleY != 1f) {
-            fx *= scaleX
-            fy *= scaleY
-            fx2 *= scaleX
-            fy2 *= scaleY
-        }
-
-        val p1x = fx
-        val p1y = fy
-        val p2x = fx
-        val p2y = fy2
-        val p3x = fx2
-        val p3y = fy2
-        val p4x = fx2
-        val p4y = fy
-
-        var x1: Float = p1x
-        var y1: Float = p1y
-        var x2: Float = p2x
-        var y2: Float = p2y
-        var x3: Float = p3x
-        var y3: Float = p3y
-        var x4: Float = p4x
-        var y4: Float = p4y
-
-        if (rotation != Angle.ZERO) {
-            val cos = rotation.cosine
-            val sin = rotation.sine
-
-            x1 = cos * p1x - sin * p1y
-            y1 = sin * p1x + cos * p1y
-
-            x2 = cos * p2x - sin * p2y
-            y2 = sin * p2x + cos * p2y
-
-            x3 = cos * p3x - sin * p3y
-            y3 = sin * p3x + cos * p3y
-
-            x4 = x1 + (x3 - x2)
-            y4 = y3 - (y2 - y1)
-        }
-
-        x1 += x
-        y1 += y
-        x2 += x
-        y2 += y
-        x3 += x
-        y3 += y
-        x4 += x
-        y4 += y
-
-        val u = if (flipX) 1f else 0f
-        val v = if (flipY) 0f else 0f
-        val u2 = if (flipX) 0f else 1f
-        val v2 = if (flipY) 1f else 1f
-
-        mesh.run {
-            setVertex { // bottom left
-                this.x = x1
-                this.y = y1
-                this.colorPacked = colorBits
-                this.u = u
-                this.v = v
-            }
-
-            setVertex { // top left
-                this.x = x2
-                this.y = y2
-                this.colorPacked = colorBits
-                this.u = u
-                this.v = v2
-            }
-
-            setVertex { // top right
-                this.x = x3
-                this.y = y3
-                this.colorPacked = colorBits
-                this.u = u2
-                this.v = v2
-            }
-
-            setVertex { // bottom right
-                this.x = x4
-                this.y = y4
-                this.colorPacked = colorBits
-                this.u = u2
-                this.v = v
-            }
-        }
-
-        idx += SPRITE_SIZE
-    }
-
-    override fun draw(
         slice: TextureSlice,
         x: Float,
         y: Float,
@@ -474,9 +352,9 @@ class SpriteBatch(
         y4 += y
 
         var u = srcX * invTexWidth
-        var v = (srcY + srcHeight) * invTexHeight
+        var v = srcY * invTexHeight
         var u2 = (srcX + srcWidth) * invTexWidth
-        var v2 = srcY * invTexHeight
+        var v2 = (srcY + srcHeight) * invTexHeight
 
         if (flipX) {
             val tmp = u

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureArraySpriteBatch.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/TextureArraySpriteBatch.kt
@@ -1,0 +1,654 @@
+package com.lehaine.littlekt.graphics
+
+import com.lehaine.littlekt.Context
+import com.lehaine.littlekt.graphics.gl.BlendFactor
+import com.lehaine.littlekt.graphics.gl.DrawMode
+import com.lehaine.littlekt.graphics.gl.State
+import com.lehaine.littlekt.graphics.shader.ShaderProgram
+import com.lehaine.littlekt.graphics.shader.shaders.DefaultFragmentShader
+import com.lehaine.littlekt.graphics.shader.shaders.DefaultVertexShader
+import com.lehaine.littlekt.math.Mat4
+import com.lehaine.littlekt.math.geom.Angle
+import com.lehaine.littlekt.math.geom.cosine
+import com.lehaine.littlekt.math.geom.sine
+import kotlin.math.min
+
+/**
+ * @author Colton Daily
+ * @date 2/8/2022
+ */
+class TextureArraySpriteBatch(
+    val context: Context,
+    val size: Int = 1000,
+) : Batch {
+    companion object {
+        private const val VERTEX_SIZE = 2 + 1 + 2
+        private const val SPRITE_SIZE = 4 * VERTEX_SIZE
+    }
+
+    private val gl get() = context.graphics.gl
+    val defaultShader = ShaderProgram(DefaultVertexShader(), DefaultFragmentShader()).also { it.prepare(context) }
+    override var shader: ShaderProgram<*, *> = defaultShader
+        set(value) {
+            if (drawing) {
+                flush()
+            }
+            field = value
+            if (drawing) {
+                field.bind()
+                setupMatrices()
+            }
+        }
+    var renderCalls = 0
+        private set
+    var totalRenderCalls = 0
+        private set
+    var maxSpritesInBatch = 0
+        private set
+
+    private var drawing = false
+    override var transformMatrix = Mat4()
+        set(value) {
+            if (drawing) {
+                flush()
+            }
+            field = value
+            if (drawing) {
+                setupMatrices()
+            }
+        }
+    override var projectionMatrix = Mat4().setToOrthographic(
+        left = 0f,
+        right = context.graphics.width.toFloat(),
+        bottom = 0f,
+        top = context.graphics.height.toFloat(),
+        near = -1f,
+        far = 1f
+    )
+        set(value) {
+            if (drawing) {
+                flush()
+            }
+            field = value
+            if (drawing) {
+                setupMatrices()
+            }
+        }
+    private var combinedMatrix = Mat4()
+
+    private val mesh = textureMesh(context.gl) {
+        isStatic = false
+        maxVertices = size * 4
+    }.apply {
+        indicesAsQuad()
+    }
+
+    private var lastTexture: Texture? = null
+    private var idx = 0
+    private var invTexWidth = 0f
+    private var invTexHeight = 0f
+
+    override var color = Color.WHITE
+        set(value) {
+            if (field == value) return
+            field = value
+            colorBits = field.toFloatBits()
+        }
+    override var colorBits = color.toFloatBits()
+
+    private var prevBlendSrcFunc = BlendFactor.SRC_ALPHA
+    private var prevBlendDstFunc = BlendFactor.ONE_MINUS_SRC_ALPHA
+    private var prevBlendSrcFuncAlpha = BlendFactor.SRC_ALPHA
+    private var prevBlendDstFuncAlpha = BlendFactor.ONE_MINUS_SRC_ALPHA
+    private var blendSrcFunc = prevBlendSrcFunc
+    private var blendDstFunc = prevBlendDstFunc
+    private var blendSrcFuncAlpha = prevBlendSrcFuncAlpha
+    private var blendDstFuncAlpha = prevBlendDstFuncAlpha
+
+    override fun begin(projectionMatrix: Mat4?) {
+        if (drawing) {
+            throw IllegalStateException("SpriteBatch.end must be called before begin.")
+        }
+        renderCalls = 0
+
+        gl.depthMask(false)
+
+        projectionMatrix?.let {
+            this.projectionMatrix = it
+        }
+        shader.bind()
+        setupMatrices()
+
+        drawing = true
+    }
+
+    override fun draw(
+        texture: Texture,
+        x: Float,
+        y: Float,
+        originX: Float,
+        originY: Float,
+        width: Float,
+        height: Float,
+        scaleX: Float,
+        scaleY: Float,
+        rotation: Angle,
+        colorBits: Float,
+        flipX: Boolean,
+        flipY: Boolean,
+    ) {
+        if (!drawing) {
+            throw IllegalStateException("SpriteBatch.begin must be called before draw.")
+        }
+        if (texture != lastTexture) {
+            switchTexture(texture)
+        } else if (idx == mesh.maxVertices) {
+            flush()
+        }
+
+        var fx = -originX
+        var fy = -originY
+        var fx2 = width - originX
+        var fy2 = height - originY
+
+        if (scaleX != 1f || scaleY != 1f) {
+            fx *= scaleX
+            fy *= scaleY
+            fx2 *= scaleX
+            fy2 *= scaleY
+        }
+
+        val p1x = fx
+        val p1y = fy
+        val p2x = fx
+        val p2y = fy2
+        val p3x = fx2
+        val p3y = fy2
+        val p4x = fx2
+        val p4y = fy
+
+        var x1: Float = p1x
+        var y1: Float = p1y
+        var x2: Float = p2x
+        var y2: Float = p2y
+        var x3: Float = p3x
+        var y3: Float = p3y
+        var x4: Float = p4x
+        var y4: Float = p4y
+
+        if (rotation != Angle.ZERO) {
+            val cos = rotation.cosine
+            val sin = rotation.sine
+
+            x1 = cos * p1x - sin * p1y
+            y1 = sin * p1x + cos * p1y
+
+            x2 = cos * p2x - sin * p2y
+            y2 = sin * p2x + cos * p2y
+
+            x3 = cos * p3x - sin * p3y
+            y3 = sin * p3x + cos * p3y
+
+            x4 = x1 + (x3 - x2)
+            y4 = y3 - (y2 - y1)
+        }
+
+        x1 += x
+        y1 += y
+        x2 += x
+        y2 += y
+        x3 += x
+        y3 += y
+        x4 += x
+        y4 += y
+
+        val u = if (flipX) 1f else 0f
+        val v = if (flipY) 0f else 0f
+        val u2 = if (flipX) 0f else 1f
+        val v2 = if (flipY) 1f else 1f
+
+        mesh.run {
+            setVertex { // bottom left
+                this.x = x1
+                this.y = y1
+                this.colorPacked = colorBits
+                this.u = u
+                this.v = v
+            }
+
+            setVertex { // top left
+                this.x = x2
+                this.y = y2
+                this.colorPacked = colorBits
+                this.u = u
+                this.v = v2
+            }
+
+            setVertex { // top right
+                this.x = x3
+                this.y = y3
+                this.colorPacked = colorBits
+                this.u = u2
+                this.v = v2
+            }
+
+            setVertex { // bottom right
+                this.x = x4
+                this.y = y4
+                this.colorPacked = colorBits
+                this.u = u2
+                this.v = v
+            }
+        }
+
+        idx += SPRITE_SIZE
+    }
+
+    override fun draw(
+        slice: TextureSlice,
+        x: Float,
+        y: Float,
+        originX: Float,
+        originY: Float,
+        width: Float,
+        height: Float,
+        scaleX: Float,
+        scaleY: Float,
+        rotation: Angle,
+        colorBits: Float,
+        flipX: Boolean,
+        flipY: Boolean,
+    ) {
+        if (!drawing) {
+            throw IllegalStateException("SpriteBatch.begin must be called before draw.")
+        }
+        if (slice.texture != lastTexture) {
+            switchTexture(slice.texture)
+        } else if (idx == mesh.maxVertices) {
+            flush()
+        }
+
+        var fx = -(originX - slice.offsetX)
+        var fy = -(originY - slice.offsetY)
+        val w = if (slice.rotated) height else width
+        val h = if (slice.rotated) width else height
+        var fx2 = w + fx
+        var fy2 = h + fy
+
+        if (scaleX != 1f || scaleY != 1f) {
+            fx *= scaleX
+            fy *= scaleY
+            fx2 *= scaleX
+            fy2 *= scaleY
+        }
+
+        val p1x = fx
+        val p1y = fy
+        val p2x = fx
+        val p2y = fy2
+        val p3x = fx2
+        val p3y = fy2
+        val p4x = fx2
+        val p4y = fy
+
+        var x1: Float
+        var y1: Float
+        var x2: Float
+        var y2: Float
+        var x3: Float
+        var y3: Float
+        var x4: Float
+        var y4: Float
+
+        if (rotation == Angle.ZERO) {
+            x1 = p1x
+            y1 = p1y
+
+            x2 = p2x
+            y2 = p2y
+
+            x3 = p3x
+            y3 = p3y
+
+            x4 = p4x
+            y4 = p4y
+        } else {
+            val cos = rotation.cosine
+            val sin = rotation.sine
+
+            x1 = cos * p1x - sin * p1y
+            y1 = sin * p1x + cos * p1y
+
+            x2 = cos * p2x - sin * p2y
+            y2 = sin * p2x + cos * p2y
+
+            x3 = cos * p3x - sin * p3y
+            y3 = sin * p3x + cos * p3y
+
+            x4 = x1 + (x3 - x2)
+            y4 = y3 - (y2 - y1)
+        }
+
+        x1 += x
+        y1 += y
+        x2 += x
+        y2 += y
+        x3 += x
+        y3 += y
+        x4 += x
+        y4 += y
+
+        val u = if (flipX) slice.u2 else slice.u
+        val v = if (flipY) slice.v else slice.v2
+        val u2 = if (flipX) slice.u else slice.u2
+        val v2 = if (flipY) slice.v2 else slice.v
+
+        mesh.run {
+            setVertex { // bottom left
+                this.x = x1
+                this.y = y1
+                this.colorPacked = colorBits
+                this.u = u
+                this.v = if (slice.rotated) v2 else v
+            }
+            setVertex { // top left
+                this.x = x2
+                this.y = y2
+                this.colorPacked = colorBits
+                this.u = if (slice.rotated) u2 else u
+                this.v = v2
+            }
+            setVertex { // top right
+                this.x = x3
+                this.y = y3
+                this.colorPacked = colorBits
+                this.u = u2
+                this.v = if (slice.rotated) v else v2
+            }
+            setVertex { // bottom right
+                this.x = x4
+                this.y = y4
+                this.colorPacked = colorBits
+                this.u = if (slice.rotated) u else u2
+                this.v = v
+            }
+        }
+
+        idx += SPRITE_SIZE
+    }
+
+    override fun draw(
+        texture: Texture,
+        x: Float,
+        y: Float,
+        originX: Float,
+        originY: Float,
+        width: Float,
+        height: Float,
+        scaleX: Float,
+        scaleY: Float,
+        rotation: Angle,
+        srcX: Int,
+        srcY: Int,
+        srcWidth: Int,
+        srcHeight: Int,
+        colorBits: Float,
+        flipX: Boolean,
+        flipY: Boolean,
+    ) {
+        if (!drawing) {
+            throw IllegalStateException("SpriteBatch.begin must be called before draw.")
+        }
+        if (texture != lastTexture) {
+            switchTexture(texture)
+        } else if (idx == mesh.maxVertices) {
+            flush()
+        }
+
+        var fx = -originX
+        var fy = -originY
+        var fx2 = width - originX
+        var fy2 = height - originY
+
+        if (scaleX != 1f || scaleY != 1f) {
+            fx *= scaleX
+            fy *= scaleY
+            fx2 *= scaleX
+            fy2 *= scaleY
+        }
+
+        val p1x = fx
+        val p1y = fy
+        val p2x = fx
+        val p2y = fy2
+        val p3x = fx2
+        val p3y = fy2
+        val p4x = fx2
+        val p4y = fy
+
+        var x1: Float
+        var y1: Float
+        var x2: Float
+        var y2: Float
+        var x3: Float
+        var y3: Float
+        var x4: Float
+        var y4: Float
+
+        if (rotation == Angle.ZERO) {
+            x1 = p1x
+            y1 = p1y
+
+            x2 = p2x
+            y2 = p2y
+
+            x3 = p3x
+            y3 = p3y
+
+            x4 = p4x
+            y4 = p4y
+        } else {
+            val cos = rotation.cosine
+            val sin = rotation.sine
+
+            x1 = cos * p1x - sin * p1y
+            y1 = sin * p1x + cos * p1y
+
+            x2 = cos * p2x - sin * p2y
+            y2 = sin * p2x + cos * p2y
+
+            x3 = cos * p3x - sin * p3y
+            y3 = sin * p3x + cos * p3y
+
+            x4 = x1 + (x3 - x2)
+            y4 = y3 - (y2 - y1)
+        }
+
+        x1 += x
+        y1 += y
+        x2 += x
+        y2 += y
+        x3 += x
+        y3 += y
+        x4 += x
+        y4 += y
+
+        var u = srcX * invTexWidth
+        var v = (srcY + srcHeight) * invTexHeight
+        var u2 = (srcX + srcWidth) * invTexWidth
+        var v2 = srcY * invTexHeight
+
+        if (flipX) {
+            val tmp = u
+            u = u2
+            u2 = tmp
+        }
+
+        if (flipY) {
+            val tmp = v
+            v = v2
+            v2 = tmp
+        }
+
+        mesh.run {
+            setVertex { // bottom left
+                this.x = x1
+                this.y = y1
+                this.colorPacked = colorBits
+                this.u = u
+                this.v = v
+            }
+            setVertex { // top left
+                this.x = x2
+                this.y = y2
+                this.colorPacked = colorBits
+                this.u = u
+                this.v = v2
+            }
+            setVertex { // top right
+                this.x = x3
+                this.y = y3
+                this.colorPacked = colorBits
+                this.u = u2
+                this.v = v2
+            }
+            setVertex { // bottom right
+                this.x = x4
+                this.y = y4
+                this.colorPacked = colorBits
+                this.u = u2
+                this.v = v
+            }
+        }
+
+        idx += SPRITE_SIZE
+    }
+
+    override fun draw(texture: Texture, spriteVertices: FloatArray, offset: Int, count: Int) {
+        if (!drawing) {
+            throw IllegalStateException("SpriteBatch.begin must be called before draw.")
+        }
+        val verticesLength: Int = mesh.batcherVerticesLength
+        var remainingVertices = verticesLength
+
+        if (texture != lastTexture) {
+            switchTexture(texture)
+        } else {
+            remainingVertices -= idx
+            if (remainingVertices == 0) {
+                flush()
+                remainingVertices = verticesLength
+            }
+        }
+
+        var copyCount = min(remainingVertices, count)
+        mesh.addVertices(spriteVertices, offset, idx, copyCount)
+        idx += copyCount
+
+        var remainingCount = count - copyCount
+        var currOffset = offset
+        while (remainingCount > 0) {
+            currOffset += copyCount
+            flush()
+            copyCount = min(verticesLength, remainingCount)
+            mesh.addVertices(spriteVertices, currOffset, 0, copyCount)
+            idx += copyCount
+            remainingCount -= copyCount
+        }
+    }
+
+    override fun end() {
+        if (!drawing) {
+            throw IllegalStateException("SpriteBatch.begin must be called before end.")
+        }
+        if (idx > 0) {
+            flush()
+        }
+        lastTexture = null
+        drawing = false
+        gl.depthMask(true)
+        gl.disable(State.BLEND)
+    }
+
+    override fun flush() {
+        if (idx == 0) {
+            return
+        }
+        renderCalls++
+        totalRenderCalls++
+        val spritesInBatch = idx / SPRITE_SIZE
+        if (spritesInBatch > maxSpritesInBatch) {
+            maxSpritesInBatch = spritesInBatch
+        }
+        val count = spritesInBatch * 6
+        lastTexture?.bind()
+        gl.enable(State.BLEND)
+        gl.blendFuncSeparate(blendSrcFunc, blendDstFunc, blendSrcFuncAlpha, blendDstFuncAlpha)
+        mesh.render(shader, DrawMode.TRIANGLES, 0, count)
+        idx = 0
+    }
+
+    override fun setBlendFunction(src: BlendFactor, dst: BlendFactor) {
+        setBlendFunctionSeparate(src, dst, src, dst)
+    }
+
+    override fun setBlendFunctionSeparate(
+        srcFuncColor: BlendFactor,
+        dstFuncColor: BlendFactor,
+        srcFuncAlpha: BlendFactor,
+        dstFuncAlpha: BlendFactor
+    ) {
+        if (blendSrcFunc == srcFuncColor && blendDstFunc == dstFuncColor
+            && blendSrcFuncAlpha == srcFuncAlpha && blendDstFuncAlpha == dstFuncAlpha
+        ) {
+            return
+        }
+        flush()
+        prevBlendSrcFunc = blendSrcFunc
+        prevBlendDstFunc = blendDstFunc
+        prevBlendSrcFuncAlpha = blendSrcFuncAlpha
+        prevBlendDstFuncAlpha = blendDstFuncAlpha
+        blendSrcFunc = srcFuncColor
+        blendDstFunc = dstFuncColor
+        blendSrcFuncAlpha = srcFuncAlpha
+        blendDstFuncAlpha = dstFuncAlpha
+    }
+
+    override fun setToPreviousBlendFunction() {
+        if (blendSrcFunc == prevBlendSrcFunc && blendDstFunc == prevBlendDstFunc
+            && blendSrcFuncAlpha == prevBlendSrcFuncAlpha && blendDstFuncAlpha == prevBlendDstFuncAlpha
+        ) {
+            return
+        }
+
+        flush()
+        blendSrcFunc = prevBlendSrcFunc
+        blendDstFunc = prevBlendDstFunc
+        blendSrcFuncAlpha = prevBlendSrcFuncAlpha
+        blendDstFuncAlpha = prevBlendDstFuncAlpha
+    }
+
+    override fun useDefaultShader() {
+        if (shader != defaultShader) {
+            shader = defaultShader
+        }
+    }
+
+    private fun switchTexture(texture: Texture) {
+        flush()
+        lastTexture = texture
+        invTexWidth = 1f / texture.width
+        invTexHeight = 1f / texture.height
+    }
+
+    private fun setupMatrices() {
+        combinedMatrix.set(projectionMatrix).mul(transformMatrix)
+        shader.uProjTrans?.apply(shader, combinedMatrix)
+        shader.uTexture?.apply(shader)
+    }
+
+    override fun dispose() {
+        mesh.dispose()
+        shader.dispose()
+    }
+}

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/BitmapFont.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/BitmapFont.kt
@@ -1,10 +1,7 @@
 package com.lehaine.littlekt.graphics.font
 
 import com.lehaine.littlekt.graph.node.component.HAlign
-import com.lehaine.littlekt.graphics.Color
-import com.lehaine.littlekt.graphics.SpriteBatch
-import com.lehaine.littlekt.graphics.Texture
-import com.lehaine.littlekt.graphics.TextureSlice
+import com.lehaine.littlekt.graphics.*
 import com.lehaine.littlekt.math.Rect
 import com.lehaine.littlekt.math.geom.Angle
 import kotlin.math.max
@@ -101,7 +98,7 @@ class BitmapFont(
      * @see [FontCache.draw]
      */
     fun draw(
-        batch: SpriteBatch,
+        batch: Batch,
         text: CharSequence,
         x: Float,
         y: Float,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/BitmapFontCache.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/BitmapFontCache.kt
@@ -1,6 +1,7 @@
 package com.lehaine.littlekt.graphics.font
 
 import com.lehaine.littlekt.graph.node.component.HAlign
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Color
 import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.math.geom.Angle
@@ -16,7 +17,7 @@ class BitmapFontCache(val font: BitmapFont) : FontCache(font.pages) {
      * Draws the text using the specified batch.
      * @param batch the batch to draw with
      */
-    fun draw(batch: SpriteBatch) {
+    fun draw(batch: Batch) {
         draw(batch, font.textures)
     }
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/BitmapFontCache.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/BitmapFontCache.kt
@@ -3,7 +3,6 @@ package com.lehaine.littlekt.graphics.font
 import com.lehaine.littlekt.graph.node.component.HAlign
 import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Color
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.math.geom.Angle
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/FontCache.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/FontCache.kt
@@ -37,7 +37,7 @@ open class FontCache(val pages: Int = 1) {
      * @param batch the batch to draw with
      * @param textures the textures to use for drawing
      */
-    fun draw(batch: SpriteBatch, textures: List<Texture>) {
+    fun draw(batch: Batch, textures: List<Texture>) {
         pageVertices.forEachIndexed { index, vertices ->
             if (vertices.isNotEmpty()) {
                 batch.draw(textures[index], vertices.data, 0, vertices.size)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/GpuFont.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/font/GpuFont.kt
@@ -203,7 +203,7 @@ class GpuFont(
     /**
      * Flushes the text mesh to be rendered.
      */
-    fun draw(batch: SpriteBatch) {
+    fun draw(batch: Batch) {
         atlases.forEach {
             if (it.uploaded) return@forEach
             it.texture.prepare(context)
@@ -219,7 +219,7 @@ class GpuFont(
      * Sets the specified [batch] to use this GPU fonts shader in order to render.
      * @param batch the batch to set the shader to
      */
-    fun useShaderWith(batch: SpriteBatch) {
+    fun useShaderWith(batch: Batch) {
         batch.shader = shader
     }
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/ShaderParameter.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/ShaderParameter.kt
@@ -191,19 +191,7 @@ sealed class ShaderParameter(val name: String) {
         }
     }
 
-    class AttributeVec2(name: String) : ShaderParameter(name) {
-        override fun create(program: ShaderProgram<*, *>) {
-            program.createAttrib(name)
-        }
-    }
-
-    class AttributeVec3(name: String) : ShaderParameter(name) {
-        override fun create(program: ShaderProgram<*, *>) {
-            program.createAttrib(name)
-        }
-    }
-
-    class AttributeVec4(name: String) : ShaderParameter(name) {
+    class Attribute(name: String) : ShaderParameter(name) {
         override fun create(program: ShaderProgram<*, *>) {
             program.createAttrib(name)
         }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/GlslGenerator.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/GlslGenerator.kt
@@ -14,6 +14,7 @@ import com.lehaine.littlekt.graphics.shader.generator.type.mat.Mat3
 import com.lehaine.littlekt.graphics.shader.generator.type.mat.Mat4
 import com.lehaine.littlekt.graphics.shader.generator.type.sampler.Sampler2D
 import com.lehaine.littlekt.graphics.shader.generator.type.sampler.Sampler2DArray
+import com.lehaine.littlekt.graphics.shader.generator.type.sampler.Sampler2DVarArray
 import com.lehaine.littlekt.graphics.shader.generator.type.sampler.ShadowTexture2D
 import com.lehaine.littlekt.graphics.shader.generator.type.scalar.GLFloat
 import com.lehaine.littlekt.graphics.shader.generator.type.scalar.GLInt
@@ -299,7 +300,7 @@ abstract class GlslGenerator : GlslProvider {
         UniformArrayDelegate(size, init, precision)
 
     fun <T : Variable> samplersArray(size: Int, precision: Precision = Precision.DEFAULT) =
-        UniformArrayDelegate(size, ::Sampler2DArray, precision)
+        UniformArrayDelegate(size, ::Sampler2DVarArray, precision)
 
     fun <RT : GenType, F : Func<RT>> Func(
         funcFactory: (GlslGenerator) -> F,
@@ -645,6 +646,7 @@ abstract class GlslGenerator : GlslProvider {
 
     fun shadow2D(sampler: ShadowTexture2D, v: Vec2) = Vec4(this, "shadow2D(${sampler.value}, ${v.value})")
     fun texture2D(sampler: Sampler2D, v: Vec2) = Vec4(this, "texture2D(${sampler.value}, ${v.value})")
+    fun texture(sampler: Sampler2DArray, v: Vec3) = Vec4(this, "texture(${sampler.value}, ${v.value})")
 
     fun float() = ConstructorDelegate(GLFloat(this))
     fun float(x: Float) = ConstructorDelegate(GLFloat(this), x.str())

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/delegate/AttributeDelegate.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/delegate/AttributeDelegate.kt
@@ -2,7 +2,6 @@ package com.lehaine.littlekt.graphics.shader.generator.delegate
 
 import com.lehaine.littlekt.graphics.shader.ShaderParameter
 import com.lehaine.littlekt.graphics.shader.generator.GlslGenerator
-import com.lehaine.littlekt.graphics.shader.generator.Instruction
 import com.lehaine.littlekt.graphics.shader.generator.Precision
 import com.lehaine.littlekt.graphics.shader.generator.type.Variable
 import kotlin.reflect.KProperty
@@ -23,11 +22,7 @@ class AttributeDelegate<T : Variable>(
     ): AttributeDelegate<T> {
         v = factory(thisRef)
         v.value = property.name
-        when (v.typeName) {
-            "vec2" -> thisRef.parameters.add(ShaderParameter.AttributeVec2(property.name))
-            "vec3" -> thisRef.parameters.add(ShaderParameter.AttributeVec3(property.name))
-            "vec4" -> thisRef.parameters.add(ShaderParameter.AttributeVec4(property.name))
-        }
+        thisRef.parameters.add(ShaderParameter.Attribute(property.name))
         return this
     }
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/type/sampler/Sampler2DArray.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/type/sampler/Sampler2DArray.kt
@@ -2,19 +2,12 @@ package com.lehaine.littlekt.graphics.shader.generator.type.sampler
 
 import com.lehaine.littlekt.graphics.shader.generator.GlslGenerator
 import com.lehaine.littlekt.graphics.shader.generator.type.Variable
-import com.lehaine.littlekt.graphics.shader.generator.type.scalar.GLInt
 
 /**
  * @author Colton Daily
- * @date 11/25/2021
+ * @date 2/9/2022
  */
 class Sampler2DArray(override val builder: GlslGenerator) : Variable {
-    override val typeName: String = "sampler2D"
+    override val typeName: String = "sampler2DArray"
     override var value: String? = null
-
-    operator fun get(i: GLInt): Sampler2D {
-        val result = Sampler2D(builder)
-        result.value = "$value[${i.value}]"
-        return result
-    }
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/type/sampler/Sampler2DVarArray.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/generator/type/sampler/Sampler2DVarArray.kt
@@ -1,0 +1,20 @@
+package com.lehaine.littlekt.graphics.shader.generator.type.sampler
+
+import com.lehaine.littlekt.graphics.shader.generator.GlslGenerator
+import com.lehaine.littlekt.graphics.shader.generator.type.Variable
+import com.lehaine.littlekt.graphics.shader.generator.type.scalar.GLInt
+
+/**
+ * @author Colton Daily
+ * @date 11/25/2021
+ */
+class Sampler2DVarArray(override val builder: GlslGenerator) : Variable {
+    override val typeName: String = "sampler2D"
+    override var value: String? = null
+
+    operator fun get(i: GLInt): Sampler2D {
+        val result = Sampler2D(builder)
+        result.value = "$value[${i.value}]"
+        return result
+    }
+}

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/shaders/GpuTextShaders.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/shaders/GpuTextShaders.kt
@@ -12,9 +12,9 @@ class GpuTextVertexShader : VertexShaderModel() {
     val uTexture = ShaderParameter.UniformSample2D("u_texture")
     val uTexelSize = ShaderParameter.UniformVec2("u_texelSize")
     val uProjTrans = ShaderParameter.UniformMat4("u_projTrans")
-    val aPosition = ShaderParameter.AttributeVec2("a_position")
-    val aColor = ShaderParameter.AttributeVec4("a_color")
-    val aTexCoord0 = ShaderParameter.AttributeVec2("a_texCoord0")
+    val aPosition = ShaderParameter.Attribute("a_position")
+    val aColor = ShaderParameter.Attribute("a_color")
+    val aTexCoord0 = ShaderParameter.Attribute("a_texCoord0")
 
     override val parameters: MutableList<ShaderParameter> =
         mutableListOf(

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/shaders/TextureArrayShaders.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/shaders/TextureArrayShaders.kt
@@ -44,7 +44,7 @@ class TextureArrayVertexShader : VertexShaderModel() {
  * @date 2/9/2022
  */
 class TextureArrayFragmentShader : FragmentShaderModel() {
-    private val u_textureArray by uniform(::Sampler2DArray)
+    private val u_textureArray by uniform(::Sampler2DArray, Precision.HIGH)
 
     private val v_textureIndex by varying(::GLFloat)
     private val v_color by varying(::Vec4, Precision.LOW)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/shaders/TextureArrayShaders.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/shaders/TextureArrayShaders.kt
@@ -1,0 +1,56 @@
+package com.lehaine.littlekt.graphics.shader.shaders
+
+import com.lehaine.littlekt.graphics.shader.FragmentShaderModel
+import com.lehaine.littlekt.graphics.shader.ShaderParameter
+import com.lehaine.littlekt.graphics.shader.VertexShaderModel
+import com.lehaine.littlekt.graphics.shader.generator.Precision
+import com.lehaine.littlekt.graphics.shader.generator.type.mat.Mat4
+import com.lehaine.littlekt.graphics.shader.generator.type.sampler.Sampler2DArray
+import com.lehaine.littlekt.graphics.shader.generator.type.scalar.GLFloat
+import com.lehaine.littlekt.graphics.shader.generator.type.vec.Vec2
+import com.lehaine.littlekt.graphics.shader.generator.type.vec.Vec4
+
+/**
+ * @author Colton Daily
+ * @date 2/9/2022
+ */
+class TextureArrayVertexShader : VertexShaderModel() {
+    val uProjTrans get() = parameters[0] as ShaderParameter.UniformMat4
+
+    private val u_projTrans by uniform(::Mat4)
+
+    private val a_position by attribute(::Vec4)
+    private val a_color by attribute(::Vec4)
+    private val a_texCoord0 by attribute(::Vec2)
+    private val a_textureIndex by attribute(::GLFloat)
+
+    private var v_color by varying(::Vec4)
+    private var v_texCoords by varying(::Vec2)
+    private var v_textureIndex by varying(::GLFloat)
+
+    init {
+        v_color = a_color
+        val alpha by float(255f.lit / 254f.lit)
+        v_color.w = v_color.w * alpha
+        v_texCoords = a_texCoord0
+        v_textureIndex = a_textureIndex
+        gl_Position = u_projTrans * a_position
+    }
+
+}
+
+/**
+ * @author Colton Daily
+ * @date 2/9/2022
+ */
+class TextureArrayFragmentShader : FragmentShaderModel() {
+    private val u_textureArray by uniform(::Sampler2DArray)
+
+    private val v_textureIndex by varying(::GLFloat)
+    private val v_color by varying(::Vec4, Precision.LOW)
+    private val v_texCoords by varying(::Vec2)
+
+    init {
+        gl_FragColor = v_color * texture(u_textureArray, vec3Lit(v_texCoords, v_textureIndex))
+    }
+}

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/TileLayer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/TileLayer.kt
@@ -1,7 +1,7 @@
 package com.lehaine.littlekt.graphics.tilemap
 
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.math.Rect
 import com.lehaine.littlekt.util.calculateViewBounds
 
@@ -12,10 +12,10 @@ import com.lehaine.littlekt.util.calculateViewBounds
 abstract class TileLayer {
     protected val viewBounds = Rect()
 
-    fun render(batch: SpriteBatch, camera: Camera, x: Float, y: Float) {
+    fun render(batch: Batch, camera: Camera, x: Float, y: Float) {
         viewBounds.calculateViewBounds(camera)
         render(batch, viewBounds, x, y)
     }
 
-    abstract fun render(batch: SpriteBatch, viewBounds: Rect, x: Float, y: Float)
+    abstract fun render(batch: Batch, viewBounds: Rect, x: Float, y: Float)
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/TileMap.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/TileMap.kt
@@ -1,10 +1,8 @@
 package com.lehaine.littlekt.graphics.tilemap
 
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.math.Rect
-import com.lehaine.littlekt.util.calculateViewBounds
-import kotlin.math.abs
 
 /**
  * @author Colton Daily
@@ -13,5 +11,5 @@ import kotlin.math.abs
 abstract class TileMap {
     protected val viewBounds = Rect()
 
-    abstract fun render(batch: SpriteBatch, camera: Camera, x: Float = 0f, y: Float = 0f)
+    abstract fun render(batch: Batch, camera: Camera, x: Float = 0f, y: Float = 0f)
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkAutoLayer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkAutoLayer.kt
@@ -1,9 +1,8 @@
 package com.lehaine.littlekt.graphics.tilemap.ldtk
 
-import com.lehaine.littlekt.graphics.SpriteBatch
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.math.Rect
 import com.lehaine.littlekt.math.geom.Angle
-import com.lehaine.littlekt.math.geom.radians
 import kotlin.math.max
 import kotlin.math.min
 
@@ -42,7 +41,7 @@ open class LDtkAutoLayer(
 
     operator fun get(coordId: Int) = autoTilesCoordIdMap[coordId]
 
-    override fun render(batch: SpriteBatch, viewBounds: Rect, x: Float, y: Float) {
+    override fun render(batch: Batch, viewBounds: Rect, x: Float, y: Float) {
         val minX = max(0, ((viewBounds.x - x - pxTotalOffsetX) / cellSize).toInt())
         val maxX = min(
             gridWidth,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkIntGridAutoLayer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkIntGridAutoLayer.kt
@@ -1,9 +1,8 @@
 package com.lehaine.littlekt.graphics.tilemap.ldtk
 
-import com.lehaine.littlekt.graphics.SpriteBatch
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.math.Rect
 import com.lehaine.littlekt.math.geom.Angle
-import com.lehaine.littlekt.math.geom.radians
 import kotlin.math.max
 import kotlin.math.min
 
@@ -43,7 +42,7 @@ open class LDtkIntGridAutoLayer(
 
     operator fun get(coordId: Int) = autoTilesCoordIdMap[coordId]
 
-    override fun render(batch: SpriteBatch, viewBounds: Rect, x: Float, y: Float) {
+    override fun render(batch: Batch, viewBounds: Rect, x: Float, y: Float) {
         val minX = max(0, ((viewBounds.x - x - pxTotalOffsetX) / cellSize).toInt())
         val maxX = min(
             gridWidth,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkLayer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkLayer.kt
@@ -1,6 +1,6 @@
 package com.lehaine.littlekt.graphics.tilemap.ldtk
 
-import com.lehaine.littlekt.graphics.SpriteBatch
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.tilemap.TileLayer
 import com.lehaine.littlekt.math.Rect
 
@@ -66,7 +66,7 @@ open class LDtkLayer(
 
     fun getCoordId(cx: Int, cy: Int) = cx + cy * gridWidth
 
-    override fun render(batch: SpriteBatch, viewBounds: Rect, x: Float, y: Float) {}
+    override fun render(batch: Batch, viewBounds: Rect, x: Float, y: Float) {}
 
     override fun toString(): String {
         return "LDtkLayer(identifier='$identifier', type=$type, cellSize=$cellSize, gridWidth=$gridWidth, gridHeight=$gridHeight, pxTotalOffsetX=$pxTotalOffsetX, pxTotalOffsetY=$pxTotalOffsetY, opacity=$opacity)"

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkLevel.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkLevel.kt
@@ -1,10 +1,7 @@
 package com.lehaine.littlekt.graphics.tilemap.ldtk
 
 import com.lehaine.littlekt.file.ldtk.LevelBackgroundPosition
-import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
-import com.lehaine.littlekt.graphics.Texture
-import com.lehaine.littlekt.graphics.TextureSlice
+import com.lehaine.littlekt.graphics.*
 import com.lehaine.littlekt.math.Rect
 import com.lehaine.littlekt.math.geom.Angle
 import com.lehaine.littlekt.util.calculateViewBounds
@@ -60,12 +57,12 @@ class LDtkLevel(
 
     private val viewBounds = Rect()
 
-    fun render(batch: SpriteBatch, camera: Camera, x: Float = worldX.toFloat(), y: Float = worldY.toFloat()) {
+    fun render(batch: Batch, camera: Camera, x: Float = worldX.toFloat(), y: Float = worldY.toFloat()) {
         viewBounds.calculateViewBounds(camera)
         render(batch, viewBounds, x, y)
     }
 
-    fun render(batch: SpriteBatch, viewBounds: Rect, x: Float = worldX.toFloat(), y: Float = worldY.toFloat()) {
+    fun render(batch: Batch, viewBounds: Rect, x: Float = worldX.toFloat(), y: Float = worldY.toFloat()) {
         levelBackgroundImage?.render(batch, x, y)
         // need to render back to front - layers last in the list need to render first
         for (i in layers.size - 1 downTo 0) {
@@ -120,7 +117,7 @@ class LDtkLevel(
         val slice: TextureSlice
     ) {
 
-        fun render(batch: SpriteBatch, x: Float, y: Float) {
+        fun render(batch: Batch, x: Float, y: Float) {
             batch.draw(
                 slice,
                 topLeftX.toFloat() + x,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkTilesLayer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkTilesLayer.kt
@@ -1,9 +1,8 @@
 package com.lehaine.littlekt.graphics.tilemap.ldtk
 
-import com.lehaine.littlekt.graphics.SpriteBatch
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.math.Rect
 import com.lehaine.littlekt.math.geom.Angle
-import com.lehaine.littlekt.math.geom.radians
 import kotlin.math.max
 import kotlin.math.min
 
@@ -38,7 +37,7 @@ open class LDtkTilesLayer(
         return tiles.contains(getCoordId(cx, cy))
     }
 
-    override fun render(batch: SpriteBatch, viewBounds: Rect, x: Float, y: Float) {
+    override fun render(batch: Batch, viewBounds: Rect, x: Float, y: Float) {
         val minX = max(0, ((viewBounds.x - x - pxTotalOffsetX) / cellSize).toInt())
         val maxX = min(
             gridWidth,

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkWorld.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/tilemap/ldtk/LDtkWorld.kt
@@ -3,8 +3,8 @@ package com.lehaine.littlekt.graphics.tilemap.ldtk
 import com.lehaine.littlekt.Disposable
 import com.lehaine.littlekt.file.ldtk.EntityDefinition
 import com.lehaine.littlekt.file.ldtk.WorldLayout
+import com.lehaine.littlekt.graphics.Batch
 import com.lehaine.littlekt.graphics.Camera
-import com.lehaine.littlekt.graphics.SpriteBatch
 import com.lehaine.littlekt.graphics.tilemap.TileMap
 import com.lehaine.littlekt.util.calculateViewBounds
 
@@ -24,7 +24,7 @@ class LDtkWorld(
 
     internal var onDispose = {}
 
-    override fun render(batch: SpriteBatch, camera: Camera, x: Float, y: Float) {
+    override fun render(batch: Batch, camera: Camera, x: Float, y: Float) {
         viewBounds.calculateViewBounds(camera)
         levels.forEach { it.render(batch, viewBounds, it.worldX + x, it.worldY + y) }
     }

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
@@ -6,10 +6,7 @@ import com.lehaine.littlekt.graphics.GLVersion
 import com.lehaine.littlekt.graphics.gl.*
 import com.lehaine.littlekt.math.Mat3
 import com.lehaine.littlekt.math.Mat4
-import org.khronos.webgl.Int32Array
-import org.khronos.webgl.Uint8Array
-import org.khronos.webgl.WebGLFramebuffer
-import org.khronos.webgl.get
+import org.khronos.webgl.*
 
 /**
  * @author Colton Daily
@@ -367,6 +364,21 @@ class WebGL(val gl: WebGL2RenderingContext, val platform: Context.Platform, priv
         gl.framebufferTexture2D(GL.FRAMEBUFFER, attachementType.glFlag, GL.TEXTURE_2D, glTexture.delegate, level)
     }
 
+    override fun frameBufferTexture2D(
+        target: Int,
+        attachementType: FrameBufferRenderBufferAttachment,
+        glTexture: GlTexture,
+        level: Int
+    ) {
+        engineStats.calls++
+        gl.framebufferTexture2D(target, attachementType.glFlag, GL.TEXTURE_2D, glTexture.delegate, level)
+    }
+
+    override fun readBuffer(mode: Int) {
+        engineStats.calls++
+        gl.readBuffer(mode)
+    }
+
     override fun checkFrameBufferStatus(): FrameBufferStatus {
         engineStats.calls++
         return FrameBufferStatus(gl.checkFramebufferStatus(GL.FRAMEBUFFER))
@@ -520,93 +532,14 @@ class WebGL(val gl: WebGL2RenderingContext, val platform: Context.Platform, priv
         gl.bindTexture(target, glTexture.delegate)
     }
 
+    override fun bindDefaultTexture(target: TextureTarget) {
+        engineStats.calls++
+        gl.bindTexture(target.glFlag, null)
+    }
+
     override fun deleteTexture(glTexture: GlTexture) {
         engineStats.calls++
         gl.deleteTexture(glTexture.delegate)
-    }
-
-    override fun compressedTexImage2D(
-        target: Int,
-        level: Int,
-        internalFormat: Int,
-        width: Int,
-        height: Int,
-        source: ByteBuffer?
-    ) {
-        engineStats.calls++
-        val dataview = (source as? ByteBufferImpl)?.buffer ?: Uint8Array(0)
-        gl.compressedTexImage2D(target, level, internalFormat, width, height, 0, dataview)
-    }
-
-    override fun compressedTexSubImage2D(
-        target: Int,
-        level: Int,
-        xOffset: Int,
-        yOffset: Int,
-        width: Int,
-        height: Int,
-        format: Int,
-        source: ByteBuffer
-    ) {
-        engineStats.calls++
-        source as ByteBufferImpl
-        gl.compressedTexSubImage2D(target, level, xOffset, yOffset, width, height, format, source.buffer)
-    }
-
-    override fun copyTexImage2D(
-        target: Int,
-        level: Int,
-        internalFormat: Int,
-        x: Int,
-        y: Int,
-        width: Int,
-        height: Int,
-        border: Int
-    ) {
-        engineStats.calls++
-        gl.copyTexImage2D(target, level, internalFormat, x, y, width, height, border)
-    }
-
-    override fun copyTexSubImage2D(
-        target: Int,
-        level: Int,
-        xOffset: Int,
-        yOffset: Int,
-        x: Int,
-        y: Int,
-        width: Int,
-        height: Int
-    ) {
-        engineStats.calls++
-        gl.copyTexSubImage2D(target, level, xOffset, yOffset, x, y, width, height)
-    }
-
-    override fun texSubImage2D(
-        target: Int,
-        level: Int,
-        xOffset: Int,
-        yOffset: Int,
-        width: Int,
-        height: Int,
-        format: Int,
-        type: Int,
-        source: ByteBuffer
-    ) {
-        engineStats.calls++
-        source as ByteBufferImpl
-        gl.texSubImage2D(target, level, xOffset, yOffset, width, height, format, type, source.buffer)
-    }
-
-    override fun texImage2D(
-        target: Int,
-        level: Int,
-        internalFormat: Int,
-        format: Int,
-        width: Int,
-        height: Int,
-        type: Int
-    ) {
-        gl.texImage2D(target, level, internalFormat, width, height, 0, format, type, null)
     }
 
     override fun uniformMatrix3fv(uniformLocation: UniformLocation, transpose: Boolean, data: Mat3) {
@@ -704,6 +637,92 @@ class WebGL(val gl: WebGL2RenderingContext, val platform: Context.Platform, priv
         gl.viewport(x, y, width, height)
     }
 
+    override fun compressedTexImage2D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        width: Int,
+        height: Int,
+        source: ByteBuffer?
+    ) {
+        engineStats.calls++
+        val dataView = (source as? ByteBufferImpl)?.buffer ?: Uint8Array(0)
+        gl.compressedTexImage2D(target, level, internalFormat, width, height, 0, dataView)
+    }
+
+    override fun compressedTexSubImage2D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        width: Int,
+        height: Int,
+        format: Int,
+        source: ByteBuffer
+    ) {
+        engineStats.calls++
+        source as ByteBufferImpl
+        gl.compressedTexSubImage2D(target, level, xOffset, yOffset, width, height, format, source.buffer)
+    }
+
+    override fun copyTexImage2D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+        border: Int
+    ) {
+        engineStats.calls++
+        gl.copyTexImage2D(target, level, internalFormat, x, y, width, height, border)
+    }
+
+    override fun copyTexSubImage2D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int
+    ) {
+        engineStats.calls++
+        gl.copyTexSubImage2D(target, level, xOffset, yOffset, x, y, width, height)
+    }
+
+    override fun texSubImage2D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        width: Int,
+        height: Int,
+        format: Int,
+        type: Int,
+        source: ByteBuffer
+    ) {
+        engineStats.calls++
+        source as ByteBufferImpl
+        gl.texSubImage2D(target, level, xOffset, yOffset, width, height, format, type, source.buffer)
+    }
+
+    override fun texImage2D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        format: Int,
+        width: Int,
+        height: Int,
+        type: Int
+    ) {
+        engineStats.calls++
+        gl.texImage2D(target, level, internalFormat, width, height, 0, format, type, null)
+    }
+
+
     override fun texImage2D(
         target: Int,
         level: Int,
@@ -718,6 +737,115 @@ class WebGL(val gl: WebGL2RenderingContext, val platform: Context.Platform, priv
         source as ByteBufferImpl
         gl.texImage2D(
             target, level, internalFormat, width, height, 0, format, type,
+            Uint8Array(source.toArray().toTypedArray()) // convert it to a uint8array or else webgl fails to render
+        )
+    }
+
+    override fun compressedTexImage3D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        source: ByteBuffer?
+    ) {
+        engineStats.calls++
+        val dataView = (source as? ByteBufferImpl)?.buffer ?: Uint8Array(0)
+        gl.compressedTexImage3D(target, level, internalFormat, width, height, depth, 0, dataView)
+    }
+
+    override fun compressedTexSubImage3D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        format: Int,
+        source: ByteBuffer
+    ) {
+        engineStats.calls++
+        source as ByteBufferImpl
+        gl.compressedTexSubImage3D(
+            target,
+            level,
+            xOffset,
+            yOffset,
+            zOffset,
+            width,
+            height,
+            depth,
+            format,
+            source.buffer
+        )
+    }
+
+    override fun copyTexSubImage3D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int
+    ) {
+        engineStats.calls++
+        gl.copyTexSubImage3D(target, level, xOffset, yOffset, zOffset, x, y, width, height)
+    }
+
+    override fun texSubImage3D(
+        target: Int,
+        level: Int,
+        xOffset: Int,
+        yOffset: Int,
+        zOffset: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        format: Int,
+        type: Int,
+        source: ByteBuffer
+    ) {
+        engineStats.calls++
+        source as ByteBufferImpl
+        gl.texSubImage3D(target, level, xOffset, yOffset, zOffset, width, height, depth, format, type, source.buffer)
+    }
+
+    override fun texImage3D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        format: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        type: Int
+    ) {
+        engineStats.calls++
+        gl.texImage3D(target, level, internalFormat, width, height, depth, 0, format, type, null as Int8Array?)
+    }
+
+    override fun texImage3D(
+        target: Int,
+        level: Int,
+        internalFormat: Int,
+        format: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        type: Int,
+        source: ByteBuffer
+    ) {
+        engineStats.calls++
+        source as ByteBufferImpl
+
+        gl.texImage3D(
+            target, level, internalFormat, width, height, depth, 0, format, type,
             Uint8Array(source.toArray().toTypedArray()) // convert it to a uint8array or else webgl fails to render
         )
     }

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLGraphics.kt
@@ -1,7 +1,6 @@
 package com.lehaine.littlekt
 
 import com.lehaine.littlekt.graphics.Cursor
-import com.lehaine.littlekt.graphics.GLVersion
 import com.lehaine.littlekt.graphics.SystemCursor
 import com.lehaine.littlekt.util.internal.jsObject
 import org.khronos.webgl.ArrayBufferView
@@ -122,6 +121,42 @@ abstract external class WebGL2RenderingContext : WebGLRenderingContext {
     fun drawElementsInstanced(mode: Int, count: Int, type: Int, offset: Int, instanceCount: Int)
     fun readBuffer(src: Int)
     fun renderbufferStorageMultisample(target: Int, samples: Int, internalformat: Int, width: Int, height: Int)
+
+    fun compressedTexImage3D(
+        target: Int,
+        level: Int,
+        internalformat: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        border: Int,
+        srcData: ArrayBufferView?
+    )
+    fun compressedTexSubImage3D(
+        target: Int,
+        level: Int,
+        xoffset: Int,
+        yoffset: Int,
+        zoffset: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        format: Int,
+        srcData: ArrayBufferView?
+    )
+
+    fun copyTexSubImage3D(
+        target: Int,
+        level: Int,
+        xoffset: Int,
+        yoffset: Int,
+        zoffset: Int,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int
+    )
+
     fun texImage3D(
         target: Int,
         level: Int,
@@ -161,6 +196,21 @@ abstract external class WebGL2RenderingContext : WebGLRenderingContext {
         type: Int,
         pixels: ImageData?
     )
+
+    fun texSubImage3D(
+        target: Int,
+        level: Int,
+        xoffset: Int,
+        yoffset: Int,
+        zoffset: Int,
+        width: Int,
+        height: Int,
+        depth: Int,
+        format: Int,
+        type: Int,
+        pixels: ArrayBufferView?
+    )
+
 
     fun texStorage2D(target: Int, levels: Int, internalformat: Int, width: Int, height: Int)
     fun texStorage3D(target: Int, levels: Int, internalformat: Int, width: Int, height: Int, depth: Int)

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/TextureArraySpriteBatchTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/TextureArraySpriteBatchTest.kt
@@ -42,7 +42,7 @@ class TextureArraySpriteBatchTest(context: Context) : ContextListener(context) {
             camera.update()
             boss.update(dt)
             batch.use(camera.viewProjection) {
-                font.draw(it, "Boobies! --- TITTIES", 50f, 50f)
+                font.draw(it, "test! --- TEST!!!", 50f, 50f)
                 boss.render(it)
                 it.draw(person, 50f, 200f)
             }

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/TextureArraySpriteBatchTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/TextureArraySpriteBatchTest.kt
@@ -1,0 +1,59 @@
+package com.lehaine.littlekt.samples
+
+import com.lehaine.littlekt.Context
+import com.lehaine.littlekt.ContextListener
+import com.lehaine.littlekt.file.vfs.readAtlas
+import com.lehaine.littlekt.file.vfs.readBitmapFont
+import com.lehaine.littlekt.file.vfs.readTexture
+import com.lehaine.littlekt.graphics.*
+import com.lehaine.littlekt.input.Key
+import com.lehaine.littlekt.util.viewport.ScreenViewport
+
+/**
+ * @author Colton Daily
+ * @date 2/9/2022
+ */
+class TextureArraySpriteBatchTest(context: Context) : ContextListener(context) {
+
+    override suspend fun Context.start() {
+        val font = resourcesVfs["m5x7_16.fnt"].readBitmapFont()
+        val atlas = resourcesVfs["tiles.atlas.json"].readAtlas()
+        val person = resourcesVfs["person.png"].readTexture()
+        val bossAttackAnim = atlas.getAnimation("bossAttack")
+        val boss = AnimatedSprite(bossAttackAnim.firstFrame).apply {
+            x = 450f
+            y = 250f
+            scaleX = 2f
+            scaleY = 2f
+            playLooped(bossAttackAnim)
+        }
+
+        val camera = OrthographicCamera(graphics.width, graphics.height).apply {
+            viewport = ScreenViewport(graphics.width, graphics.height)
+        }
+        val batch =
+            TextureArraySpriteBatch(this, maxTextureSlots = 3, maxTextureWidth = 256, maxTextureHeight = 256)
+
+        onResize { width, height ->
+            camera.update(width, height, context)
+        }
+        onRender { dt ->
+            gl.clearColor(Color.DARK_GRAY)
+            camera.update()
+            boss.update(dt)
+            batch.use(camera.viewProjection) {
+                font.draw(it, "Boobies! --- TITTIES", 50f, 50f)
+                boss.render(it)
+                it.draw(person, 50f, 200f)
+            }
+
+            if (input.isKeyJustPressed(Key.P)) {
+                logger.info { stats }
+            }
+
+            if (input.isKeyJustPressed(Key.ESCAPE)) {
+                close()
+            }
+        }
+    }
+}

--- a/samples/src/jsMain/kotlin/com/lehaine/littlekt/samples/SampleSelector.kt
+++ b/samples/src/jsMain/kotlin/com/lehaine/littlekt/samples/SampleSelector.kt
@@ -25,6 +25,8 @@ fun main() {
     document.body!!.append {
         div {
             addSample("Display Test") { DisplayTest(it) }
+            addSample("Mutable Atlas Test") { MutableAtlasTest(it) }
+            addSample("Texture Array Sprite Batch Test") { TextureArraySpriteBatchTest(it) }
         }
     }
 }

--- a/samples/src/jvmMain/kotlin/com/lehaine/littlekt/samples/TextureArraySpriteBatchTest.kt
+++ b/samples/src/jvmMain/kotlin/com/lehaine/littlekt/samples/TextureArraySpriteBatchTest.kt
@@ -1,0 +1,18 @@
+package com.lehaine.littlekt.samples
+
+import com.lehaine.littlekt.createLittleKtApp
+
+/**
+ * @author Colton Daily
+ * @date 2/9/2022
+ */
+fun main(args: Array<String>) {
+    createLittleKtApp {
+        width = 960
+        height = 540
+        vSync = true
+        title = "JVM - Texture Array Sprite Batch Test"
+    }.start {
+        TextureArraySpriteBatchTest(it)
+    }
+}


### PR DESCRIPTION
* Add new `Batch` interface
* Refactor all references to `SpriteBatch` to `Batch`
* Add new `TextureArraySpriteBatch` batch
* Add float array related methods to `Mesh` to handle getting/setting `MeshBatcher` vertices array directly
* Add `Sampler2DArray` support to `GLSLGenerator`
* Add `texImage3D` related **GL** calls