### PR TITLE
Refactor `InputMultipexer` to `InputMapController` and to handle input action callbacks

### DIFF
--- a/core/src/androidMain/kotlin/com/lehaine/littlekt/input/AndroidInput.kt
+++ b/core/src/androidMain/kotlin/com/lehaine/littlekt/input/AndroidInput.kt
@@ -170,12 +170,20 @@ class AndroidInput(private val androidCtx: Context, private val graphics: Androi
         return if (pointer == Pointer.POINTER1) deltaY else touchDeltaY[pointer.index]
     }
 
-    override fun isTouched(pointer: Pointer): Boolean {
+    override fun isJustTouched(pointer: Pointer): Boolean {
+        return inputCache.isJustTouched(pointer)
+    }
+
+    override fun isTouching(pointer: Pointer): Boolean {
         return inputCache.isTouching(pointer)
     }
 
+    override fun isTouchJustReleased(pointer: Pointer): Boolean {
+        return inputCache.isTouchJustReleased(pointer)
+    }
+
     override fun getPressure(pointer: Pointer): Float {
-        return if (isTouched(pointer)) pressures[pointer.index] else 0f
+        return if (isJustTouched(pointer)) pressures[pointer.index] else 0f
     }
 
     override fun isKeyJustPressed(key: Key): Boolean {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
@@ -89,41 +89,43 @@ inline fun <InputSignal> sceneGraph(
     ).also(callback)
 }
 
+fun <InputSignal> InputMapController<InputSignal>.addDefaultUiInput(uiInputSignals: SceneGraph.UiInputSignals<InputSignal>) {
+    uiInputSignals.uiAccept?.let {
+        addBinding(
+            it,
+            keys = listOf(Key.SPACE, Key.ENTER),
+            buttons = listOf(GameButton.XBOX_A)
+        )
+    }
+    uiInputSignals.uiSelect?.let { addBinding(it, keys = listOf(Key.SPACE), buttons = listOf(GameButton.XBOX_Y)) }
+    uiInputSignals.uiCancel?.let { addBinding(it, keys = listOf(Key.ESCAPE), buttons = listOf(GameButton.XBOX_B)) }
+    uiInputSignals.uiFocusNext?.let { addBinding(it, keys = listOf(Key.TAB)) }
+    uiInputSignals.uiFocusPrev?.let {
+        addBinding(
+            it,
+            keys = listOf(Key.TAB),
+            keyModifiers = listOf(InputMapController.KeyModifier.SHIFT)
+        )
+    }
+    uiInputSignals.uiUp?.let { addBinding(it, keys = listOf(Key.ARROW_UP), buttons = listOf(GameButton.UP)) }
+    uiInputSignals.uiDown?.let { addBinding(it, keys = listOf(Key.ARROW_DOWN), buttons = listOf(GameButton.DOWN)) }
+    uiInputSignals.uiLeft?.let { addBinding(it, keys = listOf(Key.ARROW_LEFT), buttons = listOf(GameButton.LEFT)) }
+    uiInputSignals.uiRight?.let {
+        addBinding(
+            it,
+            keys = listOf(Key.ARROW_RIGHT),
+            buttons = listOf(GameButton.RIGHT)
+        )
+    }
+    uiInputSignals.uiHome?.let { addBinding(it, keys = listOf(Key.HOME)) }
+    uiInputSignals.uiEnd?.let { addBinding(it, keys = listOf(Key.END)) }
+}
+
 fun <InputSignal> createDefaultSceneGraphController(
     input: Input,
     uiInputSignals: SceneGraph.UiInputSignals<InputSignal>
 ): InputMapController<InputSignal> =
-    InputMapController<InputSignal>(input).apply {
-        uiInputSignals.uiAccept?.let {
-            addBinding(
-                it,
-                keys = listOf(Key.SPACE, Key.ENTER),
-                buttons = listOf(GameButton.XBOX_A)
-            )
-        }
-        uiInputSignals.uiSelect?.let { addBinding(it, keys = listOf(Key.SPACE), buttons = listOf(GameButton.XBOX_Y)) }
-        uiInputSignals.uiCancel?.let { addBinding(it, keys = listOf(Key.ESCAPE), buttons = listOf(GameButton.XBOX_B)) }
-        uiInputSignals.uiFocusNext?.let { addBinding(it, keys = listOf(Key.TAB)) }
-        uiInputSignals.uiFocusPrev?.let {
-            addBinding(
-                it,
-                keys = listOf(Key.TAB),
-                keyModifiers = listOf(InputMapController.KeyModifier.SHIFT)
-            )
-        }
-        uiInputSignals.uiUp?.let { addBinding(it, keys = listOf(Key.ARROW_UP), buttons = listOf(GameButton.UP)) }
-        uiInputSignals.uiDown?.let { addBinding(it, keys = listOf(Key.ARROW_DOWN), buttons = listOf(GameButton.DOWN)) }
-        uiInputSignals.uiLeft?.let { addBinding(it, keys = listOf(Key.ARROW_LEFT), buttons = listOf(GameButton.LEFT)) }
-        uiInputSignals.uiRight?.let {
-            addBinding(
-                it,
-                keys = listOf(Key.ARROW_RIGHT),
-                buttons = listOf(GameButton.RIGHT)
-            )
-        }
-        uiInputSignals.uiHome?.let { addBinding(it, keys = listOf(Key.HOME)) }
-        uiInputSignals.uiEnd?.let { addBinding(it, keys = listOf(Key.END)) }
-    }
+    InputMapController<InputSignal>(input).also { it.addDefaultUiInput(uiInputSignals) }
 
 /**
  * A class for creating a scene graph of nodes.
@@ -477,7 +479,7 @@ open class SceneGraph<InputType>(
             }
 
             next?.grabFocus()
-            return  handled
+            return handled
         }
 
         return false

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
@@ -444,35 +444,40 @@ open class SceneGraph<InputType>(
             }
             it._uiInput(event)
             uiInput(it, event)
-            val handled = event.handled
+            var handled = event.handled
             inputEventPool.free(event)
-
-            if (handled) return true
 
             var next: Control? = null
             when (inputType) {
                 uiInputSignals.uiFocusNext -> {
                     next = it.findNextValidFocus()
+                    handled = true
                 }
                 uiInputSignals.uiFocusPrev -> {
                     next = it.findPreviousValidFocus()
+                    handled = true
                 }
                 uiInputSignals.uiUp -> {
                     next = it.getFocusNeighbor(Control.Side.TOP)
+                    handled = true
                 }
                 uiInputSignals.uiRight -> {
                     next = it.getFocusNeighbor(Control.Side.RIGHT)
+                    handled = true
                 }
                 uiInputSignals.uiDown -> {
                     next = it.getFocusNeighbor(Control.Side.BOTTOM)
+                    handled = true
                 }
                 uiInputSignals.uiLeft -> {
                     next = it.getFocusNeighbor(Control.Side.LEFT)
+                    handled = true
                 }
                 else -> Unit
             }
 
             next?.grabFocus()
+            return  handled
         }
 
         return false

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
@@ -33,7 +33,7 @@ inline fun <T : Node> Node.node(node: T, callback: @SceneGraphDslMarker T.() -> 
  * @param callback the callback that is invoked with a [Node] context in order to initialize any values
  * @return the newly created [Node]
  */
-inline fun SceneGraph.node(callback: @SceneGraphDslMarker Node.() -> Unit = {}) = root.node(callback)
+inline fun SceneGraph<*>.node(callback: @SceneGraphDslMarker Node.() -> Unit = {}) = root.node(callback)
 
 /**
  * Adds a [Node] to the current [SceneGraph.root] as a child and then triggers the [Node]. This can be used
@@ -42,7 +42,7 @@ inline fun SceneGraph.node(callback: @SceneGraphDslMarker Node.() -> Unit = {}) 
  * @param callback the callback that is invoked with a [Node] context in order to initialize any values
  * @return the newly created [Node]
  */
-inline fun <T : Node> SceneGraph.node(node: T, callback: @SceneGraphDslMarker T.() -> Unit = {}) =
+inline fun <T : Node> SceneGraph<*>.node(node: T, callback: @SceneGraphDslMarker T.() -> Unit = {}) =
     root.node(node, callback)
 
 /**
@@ -68,7 +68,7 @@ open class Node : Comparable<Node> {
     /**
      * The scene this node belongs to.
      */
-    var scene: SceneGraph? = null
+    var scene: SceneGraph<*>? = null
         set(value) {
             if (value == field) return
             field = value

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/InputEvent.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/component/InputEvent.kt
@@ -7,11 +7,12 @@ import com.lehaine.littlekt.input.Pointer
  * @author Colton Daily
  * @date 1/2/2022
  */
-class InputEvent : Event() {
+class InputEvent<InputSignal> : Event() {
     var type: Type = Type.NONE
     var pointer: Pointer = Pointer.POINTER1
     var button: Int = 0
     var key: Key = Key.ANY_KEY
+    var inputType: InputSignal? = null
     var char: Char = Char.MIN_VALUE
     var sceneX: Float = 0f
     var sceneY: Float = 0f
@@ -29,6 +30,7 @@ class InputEvent : Event() {
         sceneY = 0f
         localX = 0f
         localY = 0f
+        inputType = null
     }
 
     override fun toString(): String {
@@ -91,6 +93,21 @@ class InputEvent : Event() {
         /**
          * A keyboard character has been typed.
          */
-        CHAR_TYPED
+        CHAR_TYPED,
+
+        /**
+         * The input type action that has been pressed.
+         */
+        ACTION_DOWN,
+
+        /**
+         * The input type action that has been pressed and not released.
+         */
+        ACTION_REPEAT,
+
+        /**
+         * The input type action that has been released.
+         */
+        ACTION_UP
     }
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/Node2D.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/Node2D.kt
@@ -26,7 +26,7 @@ inline fun Node.node2d(callback: @SceneGraphDslMarker Node2D.() -> Unit = {}) =
  * @param callback the callback that is invoked with a [Node2D] context in order to initialize any values
  * @return the newly created [Node2D]
  */
-inline fun SceneGraph.node2d(callback: @SceneGraphDslMarker Node2D.() -> Unit = {}) = root.node2d(callback)
+inline fun SceneGraph<*>.node2d(callback: @SceneGraphDslMarker Node2D.() -> Unit = {}) = root.node2d(callback)
 
 /**
  * A [Node] with 2D transformations.

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/BaseButton.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/BaseButton.kt
@@ -104,7 +104,7 @@ abstract class BaseButton : Control() {
         status.pressingInside = false
     }
 
-    override fun uiInput(event: InputEvent) {
+    override fun uiInput(event: InputEvent<*>) {
         super.uiInput(event)
 
         if (event.type == InputEvent.Type.MOUSE_ENTER) {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/BaseButton.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/BaseButton.kt
@@ -1,7 +1,6 @@
 package com.lehaine.littlekt.graph.node.node2d.ui
 
 import com.lehaine.littlekt.graph.node.component.InputEvent
-import com.lehaine.littlekt.input.Key
 import com.lehaine.littlekt.util.Signal
 import com.lehaine.littlekt.util.SingleSignal
 import kotlin.js.JsName
@@ -117,8 +116,9 @@ abstract class BaseButton : Control() {
             event.handle()
         }
 
+        val uiAccept = scene?.uiInputSignals?.uiAccept
         if (event.type == InputEvent.Type.TOUCH_DOWN
-            || event.type == InputEvent.Type.KEY_DOWN && event.key == Key.SPACE
+            || event.type == InputEvent.Type.ACTION_DOWN && event.inputType == uiAccept
         ) {
             status.pressAttempt = true
             status.pressingInside = true
@@ -129,7 +129,7 @@ abstract class BaseButton : Control() {
         if (status.pressAttempt && status.pressingInside) {
             if (_toggleMode) {
                 val isPressed =
-                    event.type == InputEvent.Type.TOUCH_DOWN || event.type == InputEvent.Type.KEY_DOWN && event.key == Key.SPACE
+                    event.type == InputEvent.Type.TOUCH_DOWN || event.type == InputEvent.Type.ACTION_DOWN && event.inputType == uiAccept
                 // TODO check if shortcut input then: isPressed = false
                 if ((isPressed && actionMode == ActionMode.BUTTON_PRESS) || (!isPressed && actionMode == ActionMode.BUTTON_RELEASE)) {
                     if (actionMode == ActionMode.BUTTON_PRESS) {
@@ -142,10 +142,10 @@ abstract class BaseButton : Control() {
                     _pressed()
                 }
             } else if (((event.type == InputEvent.Type.TOUCH_DOWN
-                        || event.type == InputEvent.Type.KEY_DOWN && event.key == Key.SPACE)
+                        || event.type == InputEvent.Type.ACTION_DOWN && event.inputType == uiAccept)
                         && actionMode == ActionMode.BUTTON_PRESS)
                 || ((event.type == InputEvent.Type.TOUCH_UP
-                        || event.type == InputEvent.Type.KEY_UP && event.key == Key.SPACE)
+                        || event.type == InputEvent.Type.ACTION_UP && event.inputType == uiAccept)
                         && actionMode == ActionMode.BUTTON_RELEASE)
             ) {
                 _pressed()
@@ -153,9 +153,9 @@ abstract class BaseButton : Control() {
         }
 
         if (event.type == InputEvent.Type.TOUCH_UP
-            || event.type == InputEvent.Type.KEY_UP && event.key == Key.SPACE
+            || event.type == InputEvent.Type.ACTION_UP && event.inputType == uiAccept
         ) {
-            if (event.type == InputEvent.Type.KEY_UP
+            if (event.type == InputEvent.Type.ACTION_UP
                 || event.type == InputEvent.Type.TOUCH_UP && !hasPoint(event.sceneX, event.sceneY)
             ) {
                 status.hovering = false

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Button.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Button.kt
@@ -29,7 +29,7 @@ inline fun Node.button(callback: @SceneGraphDslMarker Button.() -> Unit = {}) =
 /**
  * Adds a [Button] to the current [SceneGraph.root] as a child and then triggers the [callback]
  */
-inline fun SceneGraph.button(callback: @SceneGraphDslMarker Button.() -> Unit = {}) =
+inline fun SceneGraph<*>.button(callback: @SceneGraphDslMarker Button.() -> Unit = {}) =
     root.button(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/CenterContainer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/CenterContainer.kt
@@ -20,7 +20,7 @@ inline fun Node.centerContainer(callback: @SceneGraphDslMarker CenterContainer.(
  * @param callback the callback that is invoked with a [CenterContainer] context in order to initialize any values
  * @return the newly created [CenterContainer]
  */
-inline fun SceneGraph.centerContainer(callback: @SceneGraphDslMarker CenterContainer.() -> Unit = {}) =
+inline fun SceneGraph<*>.centerContainer(callback: @SceneGraphDslMarker CenterContainer.() -> Unit = {}) =
     root.centerContainer(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Container.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Container.kt
@@ -24,7 +24,7 @@ inline fun Node.container(callback: @SceneGraphDslMarker Container.() -> Unit = 
  * @param callback the callback that is invoked with a [Container] context in order to initialize any values
  * @return the newly created [Container]
  */
-inline fun SceneGraph.container(callback: @SceneGraphDslMarker Container.() -> Unit = {}) = root.container(callback)
+inline fun SceneGraph<*>.container(callback: @SceneGraphDslMarker Container.() -> Unit = {}) = root.container(callback)
 
 /**
  * A [Control] node that all containers inherit from.

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Control.kt
@@ -35,7 +35,7 @@ inline fun Node.control(callback: @SceneGraphDslMarker Control.() -> Unit = {}) 
  * @param callback the callback that is invoked with a [Control] context in order to initialize any values
  * @return the newly created [Control]
  */
-inline fun SceneGraph.control(callback: @SceneGraphDslMarker Control.() -> Unit = {}) = root.control(callback)
+inline fun SceneGraph<*>.control(callback: @SceneGraphDslMarker Control.() -> Unit = {}) = root.control(callback)
 
 
 /**
@@ -65,7 +65,7 @@ open class Control : Node2D() {
     /**
      * A [Signal] that is emitted when the control receives an [InputEvent].
      */
-    val onUiInput: SingleSignal<InputEvent> = SingleSignal()
+    val onUiInput: SingleSignal<InputEvent<*>> = SingleSignal()
 
     /**
      * A [Signal] that is emitted when the control gains focus.
@@ -477,7 +477,7 @@ open class Control : Node2D() {
         super.onRemovedFromScene()
     }
 
-    internal fun _uiInput(event: InputEvent) {
+    internal fun _uiInput(event: InputEvent<*>) {
         if (!enabled || !insideTree) return
         onUiInput.emit(event) // signal is first due to being able to handle the event
         if (event.handled) {
@@ -489,7 +489,7 @@ open class Control : Node2D() {
     /**
      * Open method that is to process and accept inputs on UI elements.
      */
-    open fun uiInput(event: InputEvent) = Unit
+    open fun uiInput(event: InputEvent<*>) = Unit
 
     private fun _onThemeChanged() {
         nodes.forEach {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/HBoxContainer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/HBoxContainer.kt
@@ -15,7 +15,7 @@ inline fun Node.hBoxContainer(callback: @SceneGraphDslMarker HBoxContainer.() ->
 /**
  * Adds a [HBoxContainer] to the current [SceneGraph.root] as a child and then triggers the [callback]
  */
-inline fun SceneGraph.hBoxContainer(callback: @SceneGraphDslMarker HBoxContainer.() -> Unit = {}) =
+inline fun SceneGraph<*>.hBoxContainer(callback: @SceneGraphDslMarker HBoxContainer.() -> Unit = {}) =
     root.hBoxContainer(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Label.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Label.kt
@@ -24,7 +24,7 @@ inline fun Node.label(callback: @SceneGraphDslMarker Label.() -> Unit = {}) =
 /**
  * Adds a [Label] to the current [SceneGraph.root] as a child and then triggers the [callback]
  */
-inline fun SceneGraph.label(callback: @SceneGraphDslMarker Label.() -> Unit = {}) =
+inline fun SceneGraph<*>.label(callback: @SceneGraphDslMarker Label.() -> Unit = {}) =
     root.label(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/LineEdit.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/LineEdit.kt
@@ -32,7 +32,7 @@ inline fun Node.lineEdit(callback: @SceneGraphDslMarker LineEdit.() -> Unit = {}
 /**
  * Adds a [LineEdit] to the current [SceneGraph.root] as a child and then triggers the [callback]
  */
-inline fun SceneGraph.lineEdit(callback: @SceneGraphDslMarker LineEdit.() -> Unit = {}) =
+inline fun SceneGraph<*>.lineEdit(callback: @SceneGraphDslMarker LineEdit.() -> Unit = {}) =
     root.lineEdit(callback)
 
 /**
@@ -146,7 +146,7 @@ open class LineEdit : Control() {
         focusMode = FocusMode.ALL
     }
 
-    override fun uiInput(event: InputEvent) {
+    override fun uiInput(event: InputEvent<*>) {
         super.uiInput(event)
 
         if (event.type == InputEvent.Type.TOUCH_DOWN) {
@@ -313,7 +313,7 @@ open class LineEdit : Control() {
         }
     }
 
-    private fun onTapped(event: InputEvent) {
+    private fun onTapped(event: InputEvent<*>) {
         val count = taps % 4
         if (count == 0) unselect()
         if (count == 2) {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/NinePatchRect.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/NinePatchRect.kt
@@ -15,7 +15,7 @@ inline fun Node.ninePatchRect(callback: @SceneGraphDslMarker NinePatchRect.() ->
 /**
  * Adds a [NinePatchRect] to the current [SceneGraph.root] as a child and then triggers the [callback]
  */
-inline fun SceneGraph.ninePatchRect(callback: @SceneGraphDslMarker NinePatchRect.() -> Unit = {}) =
+inline fun SceneGraph<*>.ninePatchRect(callback: @SceneGraphDslMarker NinePatchRect.() -> Unit = {}) =
     root.ninePatchRect(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/PaddedContainer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/PaddedContainer.kt
@@ -15,7 +15,7 @@ inline fun Node.paddedContainer(callback: @SceneGraphDslMarker PaddedContainer.(
 /**
  * Adds a [PaddedContainer] to the current [SceneGraph.root] as a child and then triggers the [callback]
  */
-inline fun SceneGraph.paddedContainer(callback: @SceneGraphDslMarker PaddedContainer.() -> Unit = {}) =
+inline fun SceneGraph<*>.paddedContainer(callback: @SceneGraphDslMarker PaddedContainer.() -> Unit = {}) =
     root.paddedContainer(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Panel.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/Panel.kt
@@ -21,7 +21,7 @@ inline fun Node.panel(callback: @SceneGraphDslMarker Panel.() -> Unit = {}) =
  * @param callback the callback that is invoked with a [Panel] context in order to initialize any values
  * @return the newly created [Panel]
  */
-inline fun SceneGraph.panel(callback: @SceneGraphDslMarker Panel.() -> Unit = {}) =
+inline fun SceneGraph<*>.panel(callback: @SceneGraphDslMarker Panel.() -> Unit = {}) =
     root.panel(callback)
 
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/PanelContainer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/PanelContainer.kt
@@ -21,7 +21,7 @@ inline fun Node.panelContainer(callback: @SceneGraphDslMarker PanelContainer.() 
  * @param callback the callback that is invoked with a [PanelContainer] context in order to initialize any values
  * @return the newly created [PanelContainer]
  */
-inline fun SceneGraph.panelContainer(callback: @SceneGraphDslMarker PanelContainer.() -> Unit = {}) =
+inline fun SceneGraph<*>.panelContainer(callback: @SceneGraphDslMarker PanelContainer.() -> Unit = {}) =
     root.panelContainer(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/ProgressBar.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/ProgressBar.kt
@@ -26,7 +26,7 @@ inline fun Node.progressBar(callback: @SceneGraphDslMarker ProgressBar.() -> Uni
 /**
  * Adds a [ProgressBar] to the current [SceneGraph.root] as a child and then triggers the [callback]
  */
-inline fun SceneGraph.progressBar(callback: @SceneGraphDslMarker ProgressBar.() -> Unit = {}) =
+inline fun SceneGraph<*>.progressBar(callback: @SceneGraphDslMarker ProgressBar.() -> Unit = {}) =
     root.progressBar(callback)
 
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/TextureRect.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/TextureRect.kt
@@ -23,7 +23,7 @@ inline fun Node.textureRect(callback: @SceneGraphDslMarker TextureRect.() -> Uni
  * @param callback the callback that is invoked with a [TextureRect] context in order to initialize any values
  * @return the newly created [TextureRect]
  */
-inline fun SceneGraph.textureRect(callback: @SceneGraphDslMarker TextureRect.() -> Unit = {}) =
+inline fun SceneGraph<*>.textureRect(callback: @SceneGraphDslMarker TextureRect.() -> Unit = {}) =
     root.textureRect(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/VBoxContainer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/node2d/ui/VBoxContainer.kt
@@ -20,7 +20,7 @@ inline fun Node.vBoxContainer(callback: @SceneGraphDslMarker VBoxContainer.() ->
  * @param callback the callback that is invoked with a [VBoxContainer] context in order to initialize any values
  * @return the newly created [VBoxContainer]
  */
-inline fun SceneGraph.vBoxContainer(callback: @SceneGraphDslMarker VBoxContainer.() -> Unit = {}) =
+inline fun SceneGraph<*>.vBoxContainer(callback: @SceneGraphDslMarker VBoxContainer.() -> Unit = {}) =
     root.vBoxContainer(callback)
 
 /**

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/input/Input.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/input/Input.kt
@@ -303,7 +303,9 @@ interface Input {
     fun getDeltaX(pointer: Pointer): Int
     fun getDeltaY(pointer: Pointer): Int
 
-    fun isTouched(pointer: Pointer): Boolean
+    fun isJustTouched(pointer: Pointer): Boolean
+    fun isTouching(pointer: Pointer):Boolean
+    fun isTouchJustReleased(pointer: Pointer):Boolean
 
     fun getPressure(pointer: Pointer): Float
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapController.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapController.kt
@@ -43,9 +43,7 @@ class InputMapController<InputSignal>(
     private val pointerToType = mutableMapOf<Pointer, InputSignal>()
 
     private val axes = mutableMapOf<InputSignal, InputAxis<InputSignal>>()
-    private val axesToType = mutableMapOf<InputSignal, MutableList<InputSignal>>()
     private val vectors = mutableMapOf<InputSignal, InputVector<InputSignal>>()
-    private val vectorsToType = mutableMapOf<InputSignal, MutableList<InputSignal>>()
 
     private val processors = mutableListOf<InputMapProcessor<InputSignal>>()
 
@@ -124,8 +122,6 @@ class InputMapController<InputSignal>(
      */
     fun addAxis(type: InputSignal, positive: InputSignal, negative: InputSignal) {
         axes[type] = InputAxis(positive, negative)
-        axesToType.getOrPut(positive) { mutableListOf() }.add(type)
-        axesToType.getOrPut(negative) { mutableListOf() }.add(type)
     }
 
     /**
@@ -149,10 +145,6 @@ class InputMapController<InputSignal>(
         negativeY: InputSignal
     ) {
         vectors[type] = InputVector(positiveX, positiveY, negativeX, negativeY)
-        vectorsToType.getOrPut(positiveX) { mutableListOf() }.add(type)
-        vectorsToType.getOrPut(negativeX) { mutableListOf() }.add(type)
-        vectorsToType.getOrPut(positiveY) { mutableListOf() }.add(type)
-        vectorsToType.getOrPut(negativeY) { mutableListOf() }.add(type)
     }
 
     val isTouching get() = input.isTouching
@@ -203,20 +195,8 @@ class InputMapController<InputSignal>(
         if (processors.isEmpty()) return false
         pointerToType[pointer]?.let {
             processors.forEach { processor ->
-                var handled = processor.onActionDown(it)
+                val handled = processor.onActionDown(it)
                 if (handled) return true
-
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
             }
         }
         return false
@@ -226,20 +206,8 @@ class InputMapController<InputSignal>(
         if (processors.isEmpty()) return false
         pointerToType[pointer]?.let {
             processors.forEach { processor ->
-                var handled = processor.onActionUp(it)
+                val handled = processor.onActionUp(it)
                 if (handled) return true
-
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
             }
         }
         return false
@@ -263,37 +231,15 @@ class InputMapController<InputSignal>(
                 // if we get here then all the modifiers are met
                 val inputSignal = binding.input
                 processors.forEach { processor ->
-                    var handled = processor.onActionDown(inputSignal)
+                    val handled = processor.onActionDown(inputSignal)
                     if (handled) return true
-                    axesToType[inputSignal]?.forEach {
-                        val axis = axis(it)
-                        handled = processor.onAxisChanged(it, axis)
-                        if (handled) return true
-                    }
-
-                    vectorsToType[inputSignal]?.forEach {
-                        val vector = vector(it)
-                        handled = processor.onVectorChanged(it, vector.x, vector.y)
-                        if (handled) return true
-                    }
                 }
             }
         } else {
             keyToType[key]?.let {
                 processors.forEach { processor ->
-                    var handled = processor.onActionDown(it)
+                    val handled = processor.onActionDown(it)
                     if (handled) return true
-                    axesToType[it]?.forEach {
-                        val axis = axis(it)
-                        handled = processor.onAxisChanged(it, axis)
-                        if (handled) return true
-                    }
-
-                    vectorsToType[it]?.forEach {
-                        val vector = vector(it)
-                        handled = processor.onVectorChanged(it, vector.x, vector.y)
-                        if (handled) return true
-                    }
                 }
             }
         }
@@ -306,19 +252,8 @@ class InputMapController<InputSignal>(
 
         keyToType[key]?.let {
             processors.forEach { processor ->
-                var handled = processor.onActionRepeat(it)
+                val handled = processor.onActionRepeat(it)
                 if (handled) return true
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
             }
         }
         return false
@@ -330,19 +265,8 @@ class InputMapController<InputSignal>(
 
         keyToType[key]?.let {
             processors.forEach { processor ->
-                var handled = processor.onActionUp(it)
+                val handled = processor.onActionUp(it)
                 if (handled) return true
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
             }
         }
         return false
@@ -354,19 +278,8 @@ class InputMapController<InputSignal>(
 
         buttonToType[button]?.let {
             processors.forEach { processor ->
-                var handled = processor.onActionDown(it)
+                val handled = processor.onActionDown(it)
                 if (handled) return true
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
             }
         }
         return false
@@ -378,60 +291,8 @@ class InputMapController<InputSignal>(
 
         buttonToType[button]?.let {
             processors.forEach { processor ->
-                var handled = processor.onActionUp(it)
+                val handled = processor.onActionUp(it)
                 if (handled) return true
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
-            }
-        }
-        return false
-    }
-
-    override fun gamepadJoystickMoved(stick: GameStick, xAxis: Float, yAxis: Float, gamepad: Int): Boolean {
-        mode = InputMode.GAMEPAD
-        if (processors.isEmpty()) return false
-
-        var gameAxis = if (stick == GameStick.LEFT) GameAxis.LX else GameAxis.RX
-        axisToType[gameAxis]?.let { it ->
-            processors.forEach { processor ->
-                var handled: Boolean
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
-            }
-        }
-        gameAxis = if (stick == GameStick.LEFT) GameAxis.LY else GameAxis.RY
-        axisToType[gameAxis]?.let {
-            processors.forEach { processor ->
-                var handled: Boolean
-                axesToType[it]?.forEach {
-                    val axis = axis(it)
-                    handled = processor.onAxisChanged(it, axis)
-                    if (handled) return true
-                }
-
-                vectorsToType[it]?.forEach {
-                    val vector = vector(it)
-                    handled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (handled) return true
-                }
             }
         }
         return false

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapController.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapController.kt
@@ -43,7 +43,9 @@ class InputMapController<InputSignal>(
     private val pointerToType = mutableMapOf<Pointer, InputSignal>()
 
     private val axes = mutableMapOf<InputSignal, InputAxis<InputSignal>>()
+    private val axesToType = mutableMapOf<InputSignal, MutableList<InputSignal>>()
     private val vectors = mutableMapOf<InputSignal, InputVector<InputSignal>>()
+    private val vectorsToType = mutableMapOf<InputSignal, MutableList<InputSignal>>()
 
     private val processors = mutableListOf<InputMapProcessor<InputSignal>>()
 
@@ -122,6 +124,8 @@ class InputMapController<InputSignal>(
      */
     fun addAxis(type: InputSignal, positive: InputSignal, negative: InputSignal) {
         axes[type] = InputAxis(positive, negative)
+        axesToType.getOrPut(positive) { mutableListOf() }.add(type)
+        axesToType.getOrPut(negative) { mutableListOf() }.add(type)
     }
 
     /**
@@ -145,6 +149,10 @@ class InputMapController<InputSignal>(
         negativeY: InputSignal
     ) {
         vectors[type] = InputVector(positiveX, positiveY, negativeX, negativeY)
+        vectorsToType.getOrPut(positiveX) { mutableListOf() }.add(type)
+        vectorsToType.getOrPut(negativeX) { mutableListOf() }.add(type)
+        vectorsToType.getOrPut(positiveY) { mutableListOf() }.add(type)
+        vectorsToType.getOrPut(negativeY) { mutableListOf() }.add(type)
     }
 
     val isTouching get() = input.isTouching
@@ -198,13 +206,13 @@ class InputMapController<InputSignal>(
                 var handled = processor.onActionDown(it)
                 if (handled) return true
 
-                if (axisBindings.containsKey(it)) {
+                axesToType[it]?.forEach {
                     val axis = axis(it)
                     handled = processor.onAxisChanged(it, axis)
                     if (handled) return true
                 }
 
-                if (vectors.containsKey(it)) {
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
                     handled = processor.onVectorChanged(it, vector.x, vector.y)
                     if (handled) return true
@@ -221,12 +229,13 @@ class InputMapController<InputSignal>(
                 var handled = processor.onActionUp(it)
                 if (handled) return true
 
-                if (axisBindings.containsKey(it)) {
+                axesToType[it]?.forEach {
                     val axis = axis(it)
                     handled = processor.onAxisChanged(it, axis)
                     if (handled) return true
                 }
-                if (vectors.containsKey(it)) {
+
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
                     handled = processor.onVectorChanged(it, vector.x, vector.y)
                     if (handled) return true
@@ -256,14 +265,15 @@ class InputMapController<InputSignal>(
                 processors.forEach { processor ->
                     var handled = processor.onActionDown(inputSignal)
                     if (handled) return true
-                    if (axisBindings.containsKey(inputSignal)) {
-                        val axis = axis(inputSignal)
-                        handled = processor.onAxisChanged(inputSignal, axis)
+                    axesToType[inputSignal]?.forEach {
+                        val axis = axis(it)
+                        handled = processor.onAxisChanged(it, axis)
                         if (handled) return true
                     }
-                    if (vectors.containsKey(inputSignal)) {
-                        val vector = vector(inputSignal)
-                        handled = processor.onVectorChanged(inputSignal, vector.x, vector.y)
+
+                    vectorsToType[inputSignal]?.forEach {
+                        val vector = vector(it)
+                        handled = processor.onVectorChanged(it, vector.x, vector.y)
                         if (handled) return true
                     }
                 }
@@ -273,12 +283,13 @@ class InputMapController<InputSignal>(
                 processors.forEach { processor ->
                     var handled = processor.onActionDown(it)
                     if (handled) return true
-                    if (axisBindings.containsKey(it)) {
+                    axesToType[it]?.forEach {
                         val axis = axis(it)
                         handled = processor.onAxisChanged(it, axis)
                         if (handled) return true
                     }
-                    if (vectors.containsKey(it)) {
+
+                    vectorsToType[it]?.forEach {
                         val vector = vector(it)
                         handled = processor.onVectorChanged(it, vector.x, vector.y)
                         if (handled) return true
@@ -297,12 +308,13 @@ class InputMapController<InputSignal>(
             processors.forEach { processor ->
                 var handled = processor.onActionRepeat(it)
                 if (handled) return true
-                if (axisBindings.containsKey(it)) {
+                axesToType[it]?.forEach {
                     val axis = axis(it)
                     handled = processor.onAxisChanged(it, axis)
                     if (handled) return true
                 }
-                if (vectors.containsKey(it)) {
+
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
                     handled = processor.onVectorChanged(it, vector.x, vector.y)
                     if (handled) return true
@@ -320,12 +332,13 @@ class InputMapController<InputSignal>(
             processors.forEach { processor ->
                 var handled = processor.onActionUp(it)
                 if (handled) return true
-                if (axisBindings.containsKey(it)) {
+                axesToType[it]?.forEach {
                     val axis = axis(it)
                     handled = processor.onAxisChanged(it, axis)
                     if (handled) return true
                 }
-                if (vectors.containsKey(it)) {
+
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
                     handled = processor.onVectorChanged(it, vector.x, vector.y)
                     if (handled) return true
@@ -343,12 +356,13 @@ class InputMapController<InputSignal>(
             processors.forEach { processor ->
                 var handled = processor.onActionDown(it)
                 if (handled) return true
-                if (axisBindings.containsKey(it)) {
+                axesToType[it]?.forEach {
                     val axis = axis(it)
                     handled = processor.onAxisChanged(it, axis)
                     if (handled) return true
                 }
-                if (vectors.containsKey(it)) {
+
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
                     handled = processor.onVectorChanged(it, vector.x, vector.y)
                     if (handled) return true
@@ -366,12 +380,13 @@ class InputMapController<InputSignal>(
             processors.forEach { processor ->
                 var handled = processor.onActionUp(it)
                 if (handled) return true
-                if (axisBindings.containsKey(it)) {
+                axesToType[it]?.forEach {
                     val axis = axis(it)
                     handled = processor.onAxisChanged(it, axis)
                     if (handled) return true
                 }
-                if (vectors.containsKey(it)) {
+
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
                     handled = processor.onVectorChanged(it, vector.x, vector.y)
                     if (handled) return true
@@ -388,10 +403,14 @@ class InputMapController<InputSignal>(
         var gameAxis = if (stick == GameStick.LEFT) GameAxis.LX else GameAxis.RX
         axisToType[gameAxis]?.let { it ->
             processors.forEach { processor ->
-                val axis = axis(it)
-                var handled = processor.onAxisChanged(it, axis)
-                if (handled) return true
-                if (vectors.containsKey(it)) {
+                var handled: Boolean
+                axesToType[it]?.forEach {
+                    val axis = axis(it)
+                    handled = processor.onAxisChanged(it, axis)
+                    if (handled) return true
+                }
+
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
                     handled = processor.onVectorChanged(it, vector.x, vector.y)
                     if (handled) return true
@@ -401,13 +420,17 @@ class InputMapController<InputSignal>(
         gameAxis = if (stick == GameStick.LEFT) GameAxis.LY else GameAxis.RY
         axisToType[gameAxis]?.let {
             processors.forEach { processor ->
-                val axis = axis(it)
-                var hanndled = processor.onAxisChanged(it, axis)
-                if (hanndled) return true
-                if (vectors.containsKey(it)) {
+                var handled: Boolean
+                axesToType[it]?.forEach {
+                    val axis = axis(it)
+                    handled = processor.onAxisChanged(it, axis)
+                    if (handled) return true
+                }
+
+                vectorsToType[it]?.forEach {
                     val vector = vector(it)
-                    hanndled = processor.onVectorChanged(it, vector.x, vector.y)
-                    if (hanndled) return true
+                    handled = processor.onVectorChanged(it, vector.x, vector.y)
+                    if (handled) return true
                 }
             }
         }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapProcessor.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapProcessor.kt
@@ -9,6 +9,4 @@ interface InputMapProcessor<InputSignal> : InputProcessor {
     fun onActionUp(inputType: InputSignal): Boolean = false
     fun onActionRepeat(inputType: InputSignal): Boolean = false
     fun onActionChange(inputType: InputSignal, pressure: Float): Boolean = false
-    fun onAxisChanged(inputType: InputSignal, axis: Float): Boolean = false
-    fun onVectorChanged(inputType: InputSignal, xAxis: Float, yAxis: Float): Boolean = false
 }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapProcessor.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapProcessor.kt
@@ -1,0 +1,14 @@
+package com.lehaine.littlekt.input
+
+/**
+ * @author Colton Daily
+ * @date 2/22/2022
+ */
+interface InputMapProcessor<InputSignal> {
+    fun onActionDown(type: InputSignal): Boolean = false
+    fun onActionUp(type: InputSignal): Boolean = false
+    fun onActionRepeat(type: InputSignal): Boolean = false
+    fun onActionChange(type: InputSignal, pressure: Float): Boolean = false
+    fun onAxisChanged(type: InputSignal, axis: Float): Boolean = false
+    fun onVectorChanged(type: InputSignal, xAxis: Float, yAxis: Float): Boolean = false
+}

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapProcessor.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/input/InputMapProcessor.kt
@@ -4,11 +4,11 @@ package com.lehaine.littlekt.input
  * @author Colton Daily
  * @date 2/22/2022
  */
-interface InputMapProcessor<InputSignal> {
-    fun onActionDown(type: InputSignal): Boolean = false
-    fun onActionUp(type: InputSignal): Boolean = false
-    fun onActionRepeat(type: InputSignal): Boolean = false
-    fun onActionChange(type: InputSignal, pressure: Float): Boolean = false
-    fun onAxisChanged(type: InputSignal, axis: Float): Boolean = false
-    fun onVectorChanged(type: InputSignal, xAxis: Float, yAxis: Float): Boolean = false
+interface InputMapProcessor<InputSignal> : InputProcessor {
+    fun onActionDown(inputType: InputSignal): Boolean = false
+    fun onActionUp(inputType: InputSignal): Boolean = false
+    fun onActionRepeat(inputType: InputSignal): Boolean = false
+    fun onActionChange(inputType: InputSignal, pressure: Float): Boolean = false
+    fun onAxisChanged(inputType: InputSignal, axis: Float): Boolean = false
+    fun onVectorChanged(inputType: InputSignal, xAxis: Float, yAxis: Float): Boolean = false
 }

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/input/JsInput.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/input/JsInput.kt
@@ -261,12 +261,20 @@ class JsInput(val canvas: HTMLCanvasElement) : Input {
         return if (pointer == Pointer.POINTER1) deltaY else 0
     }
 
-    override fun isTouched(pointer: Pointer): Boolean {
+    override fun isJustTouched(pointer: Pointer): Boolean {
+        return inputCache.isJustTouched(pointer)
+    }
+
+    override fun isTouching(pointer: Pointer): Boolean {
         return inputCache.isTouching(pointer)
     }
 
+    override fun isTouchJustReleased(pointer: Pointer): Boolean {
+        return inputCache.isTouchJustReleased(pointer)
+    }
+
     override fun getPressure(pointer: Pointer): Float {
-        return if (isTouched(pointer)) 1f else 0f
+        return if (isJustTouched(pointer)) 1f else 0f
     }
 
     override fun isKeyJustPressed(key: Key): Boolean {

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/input/LwjglInput.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/input/LwjglInput.kt
@@ -232,12 +232,20 @@ class LwjglInput : Input {
         return if (pointer == Pointer.POINTER1) deltaY else 0
     }
 
-    override fun isTouched(pointer: Pointer): Boolean {
+    override fun isJustTouched(pointer: Pointer): Boolean {
+        return inputCache.isJustTouched(pointer)
+    }
+
+    override fun isTouching(pointer: Pointer): Boolean {
         return inputCache.isTouching(pointer)
     }
 
+    override fun isTouchJustReleased(pointer: Pointer): Boolean {
+        return inputCache.isTouchJustReleased(pointer)
+    }
+
     override fun getPressure(pointer: Pointer): Float {
-        return if (isTouched(pointer)) 1f else 0f
+        return if (isJustTouched(pointer)) 1f else 0f
     }
 
     override fun isKeyJustPressed(key: Key): Boolean {

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -20,7 +20,7 @@ import com.lehaine.littlekt.graphics.shader.shaders.SimpleColorVertexShader
 import com.lehaine.littlekt.graphics.tilemap.ldtk.LDtkWorld
 import com.lehaine.littlekt.input.GameAxis
 import com.lehaine.littlekt.input.GameButton
-import com.lehaine.littlekt.input.InputMultiplexer
+import com.lehaine.littlekt.input.InputMapController
 import com.lehaine.littlekt.input.Key
 import com.lehaine.littlekt.log.Logger
 import com.lehaine.littlekt.math.MutableVec2f
@@ -44,7 +44,7 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
 
     private var xVel = 0f
     private var yVel = 0f
-    private val controller = InputMultiplexer<GameInput>(input)
+    private val controller = InputMapController<GameInput>(input)
     val camera = OrthographicCamera(graphics.width, graphics.height).apply {
         viewport = ExtendViewport(960, 540)
     }

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -487,12 +487,6 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
             }
         }
 
-        controller.addInputMapProcessor(object : InputMapProcessor<InputMap> {
-            override fun onVectorChanged(inputType: InputMap, xAxis: Float, yAxis: Float): Boolean {
-                return super.onVectorChanged(inputType, xAxis, yAxis)
-            }
-        })
-
         onResize { width, height ->
             println("resize $width,$height")
             camera.update(width, height, context)

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -102,7 +102,7 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
         controller.addBinding(GameInput.MOVE_RIGHT, listOf(Key.D, Key.ARROW_RIGHT), axes = listOf(GameAxis.LX))
         controller.addBinding(GameInput.MOVE_UP, listOf(Key.W, Key.ARROW_UP), axes = listOf(GameAxis.LY))
         controller.addBinding(GameInput.MOVE_DOWN, listOf(Key.S, Key.ARROW_DOWN), axes = listOf(GameAxis.LY))
-        controller.addBinding(GameInput.JUMP, listOf(Key.SPACE), listOf(GameButton.XBOX_A))
+        controller.addBinding(GameInput.JUMP, listOf(Key.SPACE), buttons = listOf(GameButton.XBOX_A))
         controller.addAxis(GameInput.HORIZONTAL, GameInput.MOVE_RIGHT, GameInput.MOVE_LEFT)
         controller.addAxis(GameInput.VERTICAL, GameInput.MOVE_DOWN, GameInput.MOVE_UP)
         controller.addVector(


### PR DESCRIPTION
* Rename `InputMultiplexer` to `InputMapController`
* Add new `InputMapProcessor` interface with `onAction` callbacks used with `InputMapController`
* Update `InputMapController` to handle `Pointer` types as a binding
* Update `InputMapController` to handle key modifiers in a binding (SHIFT, CTRL, and ALT)
* Update `SceneGraph` to use an `InputMapController` and input actions
* Update `SceneGraph` focus keybinds to use action bindings
* Add a helper methods to set default UI input action bindings to for `SceneGraph`