### PR TITLE
pool: add builder function to create a Pool instance before allocatin…

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/util/datastructure/Pool.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/util/datastructure/Pool.kt
@@ -2,12 +2,43 @@ package com.lehaine.littlekt.util.datastructure
 
 
 /**
+ * Creates a [Pool] instance and then generates the object by passing in the Pool instance.
+ * @param preallocate the number of objects to preallocate
+ * @param gen the object generate function to create a new object when needed
+ */
+fun <T> pool(preallocate: Int = 0, gen: Pool<T>.(Int) -> T): Pool<T> {
+    val pool = Pool<T>()
+    pool.preAlloc(preallocate, gen)
+    return pool
+}
+
+/**
  * Structure containing a set of reusable objects.
  *
  * The method [alloc] retrieves from the pool or allocates a new object,
  * while the [free] method pushes back one element to the pool and resets it to reuse it.
  */
-class Pool<T>(private val reset: (T) -> Unit = {}, preallocate: Int = 0, private val gen: (Int) -> T) {
+class Pool<T> internal constructor() {
+    private var reset: (T) -> Unit = {}
+    private var gen: ((Int) -> T)? = null
+
+    /**
+     * Structure containing a set of reusable objects.
+     * @param reset the function that reset an existing object to its initial state
+     * @param preallocate the number of objects to preallocate
+     * @param gen the object generate function to create a new object when needed
+     */
+    constructor(reset: (T) -> Unit = {}, preallocate: Int = 0, gen: (Int) -> T) : this() {
+        this.reset = reset
+        this.gen = gen
+        preAlloc(preallocate, gen)
+    }
+
+    /**
+     * Structure containing a set of reusable objects.
+     * @param preallocate the number of objects to preallocate
+     * @param gen the object generate function to create a new object when needed
+     */
     constructor(preallocate: Int = 0, gen: (Int) -> T) : this({}, preallocate, gen)
 
     private val items = Stack<T>()
@@ -17,12 +48,17 @@ class Pool<T>(private val reset: (T) -> Unit = {}, preallocate: Int = 0, private
     val totalItemsInUse get() = totalAllocatedItems - itemsInPool
     val itemsInPool: Int get() = items.size
 
-    init {
+    private fun preAlloc(preallocate: Int, gen: (Int) -> T) {
+        for (n in 0 until preallocate) items.push(gen(lastId++))
+    }
+
+    internal fun preAlloc(preallocate: Int, gen: Pool<T>.(Int) -> T) {
         for (n in 0 until preallocate) items.push(gen(lastId++))
     }
 
     fun alloc(): T {
-        return if (items.isNotEmpty()) items.pop() else gen(lastId++)
+        return if (items.isNotEmpty()) items.pop() else gen?.invoke(lastId++)
+            ?: error("Pool<T> was not instantiated with a generator function!")
     }
 
     fun free(element: T) {
@@ -52,7 +88,7 @@ class Pool<T>(private val reset: (T) -> Unit = {}, preallocate: Int = 0, private
     inline fun <R> allocMultiple(
         count: Int,
         temp: MutableList<T> = mutableListOf(),
-        callback: (MutableList<T>) -> R
+        callback: (MutableList<T>) -> R,
     ): R {
         temp.clear()
         for (n in 0 until count) temp.add(alloc())


### PR DESCRIPTION
…g objects

pool: restructure internal gen and reset functions and constructors to allow setting and allocating objects after pool instantiation