### PR TITLE
Add arm64 dependencies for LWJGL

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -72,27 +72,36 @@ kotlin {
                 }"
                 implementation(libs.lwjgl)
                 implementation("$lwjglModule:natives-windows")
+                implementation("$lwjglModule:natives-windows-arm64")
                 implementation("$lwjglModule:natives-linux")
+                implementation("$lwjglModule:natives-linux-arm64")
                 implementation("$lwjglModule:natives-macos")
+                implementation("$lwjglModule:natives-macos-arm64")
 
                 implementation(libs.lwjgl.glfw)
                 implementation("$lwjglGlfwModule:natives-windows")
+                implementation("$lwjglGlfwModule:natives-windows-arm64")
                 implementation("$lwjglGlfwModule:natives-linux")
+                implementation("$lwjglGlfwModule:natives-linux-arm64")
                 implementation("$lwjglGlfwModule:natives-macos")
+                implementation("$lwjglGlfwModule:natives-macos-arm64")
 
 
                 implementation(libs.lwjgl.opengl)
                 implementation("$lwjglOpenGlModule:natives-windows")
+                implementation("$lwjglOpenGlModule:natives-windows-arm64")
                 implementation("$lwjglOpenGlModule:natives-linux")
+                implementation("$lwjglOpenGlModule:natives-linux-arm64")
                 implementation("$lwjglOpenGlModule:natives-macos")
+                implementation("$lwjglOpenGlModule:natives-macos-arm64")
 
                 implementation(libs.lwjgl.openal)
                 implementation("$lwjglOpenAlModule:natives-windows")
-                implementation("$lwjglOpenAlModule:natives-windows-x86")
+                implementation("$lwjglOpenAlModule:natives-windows-arm64")
                 implementation("$lwjglOpenAlModule:natives-linux")
-                implementation("$lwjglOpenAlModule:natives-linux-arm32")
                 implementation("$lwjglOpenAlModule:natives-linux-arm64")
                 implementation("$lwjglOpenAlModule:natives-macos")
+                implementation("$lwjglOpenAlModule:natives-macos-arm64")
 
                 implementation(libs.mp3.decoder)
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlinx-serialization = "1.3.3"
 kotlinx-coroutines = "1.6.4"
 kotlinx-atomicfu = "0.18.2"
 
-lwjgl = "3.3.0"
+lwjgl = "3.3.1"
 
 mp3-decoder = "1.0.1"
 


### PR DESCRIPTION
`arm64` for Windows, MacOS, and Linux.