### PR TITLE
Update `NodeList` to keep original children order while using custom render sort

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/CanvasItem.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/CanvasItem.kt
@@ -409,7 +409,7 @@ abstract class CanvasItem : Node() {
         if (!enabled || !visible || isDestroyed) return
         preRender(batch, camera)
         onPreRender.emit(batch, camera)
-        nodes.forEach {
+        nodes.forEachSorted {
             if (it is CanvasItem) {
                 it.propagatePreRender(batch, camera)
             }
@@ -424,7 +424,7 @@ abstract class CanvasItem : Node() {
         renderCallback?.invoke(this, batch, camera)
         render(batch, camera)
         onRender.emit(batch, camera)
-        nodes.forEach {
+        nodes.forEachSorted {
             it.propagateInternalRender(batch, camera, renderCallback)
         }
     }
@@ -433,7 +433,7 @@ abstract class CanvasItem : Node() {
         if (!enabled || !visible || isDestroyed) return
         postRender(batch, camera)
         onPostRender.emit(batch, camera)
-        nodes.forEach {
+        nodes.forEachSorted {
             if (it is CanvasItem) {
                 it.propagatePostRender(batch, camera)
             }

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/YSortTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/YSortTest.kt
@@ -82,6 +82,9 @@ class YSortTest(context: Context) : ContextListener(context) {
                 x = 150f
 
                 onUpdate += {
+                    if(input.isKeyPressed(Key.SPACE)) {
+                        println("RED!!")
+                    }
                     if (input.isKeyJustPressed(Key.ENTER)) {
                         y = 45f
                     }
@@ -91,8 +94,12 @@ class YSortTest(context: Context) : ContextListener(context) {
             node(TestNode()) {
                 color = Color.GREEN
                 y = 50f
+                y = 50f
                 x = 150f
                 onUpdate += {
+                    if(input.isKeyPressed(Key.SPACE)) {
+                        println("GREEN!!")
+                    }
                     if (input.isKeyJustPressed(Key.ENTER)) {
                         y = 40f
                     }


### PR DESCRIPTION
Previously, sorting with `ySort` or any custom sort would sort the `nodes` list directly which would change the order in which the `Node.update()` method is invoked. This change allows to keep the original update order while using a custom sort to allow for rendering in a different order.