### PR TITLE
Refactor `Context` main game loop, render, and resize methods to be non-suspending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@
     * **For Example**: `getThemeDrawable()` will return a result and then is cached in the `drawableCache` map. Any
       subsequent calls to `getThemeDrawable()` will first check in the `drawableOverrides` and then in
       the `drawableCache` map and return a result if it exists.
-    * When a theme owners theme changes, the theme owners and its child control nodes will all have their caches cleared.
-* Add an expirmental API for rendering scalable TrueType Fonts (TTF) called `VectorFont`. A sample `VectorFontTest` exists for usage.
-*
+    * When a theme owners theme changes, the theme owners and its child control nodes will all have their caches
+      cleared.
+* Add an expirmental API for rendering scalable TrueType Fonts (TTF) called `VectorFont`. A sample `VectorFontTest`
+  exists for usage.
+
+### Breaking
+
+* `Context.onRender`, `Context.onPostRender`, `Context.onPostRunnable` is now non-suspending. This fixed issues with the
+  Android and Web platforms from creating unneeded coroutines every frame. Wrap any suspending calls called within these
+  callbacks in a coroutine, `KtScope.launch { }`, or check if the suspending function can be made non-suspending.
+
 ### New
 
 * add: `EmptyDrawable` to handle drawables that don't need drawn.

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/Context.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/Context.kt
@@ -30,11 +30,11 @@ abstract class Context {
         val isMobile get() = this == ANDROID || this == IOS
     }
 
-    protected val renderCalls = mutableListOf<suspend (Duration) -> Unit>()
-    protected val postRenderCalls = mutableListOf<suspend (Duration) -> Unit>()
-    protected val resizeCalls = mutableListOf<suspend (Int, Int) -> Unit>()
+    protected val renderCalls = mutableListOf<(Duration) -> Unit>()
+    protected val postRenderCalls = mutableListOf<(Duration) -> Unit>()
+    protected val resizeCalls = mutableListOf<(Int, Int) -> Unit>()
     protected val disposeCalls = mutableListOf<suspend () -> Unit>()
-    protected val postRunnableCalls = mutableListOf<suspend () -> Unit>()
+    protected val postRunnableCalls = mutableListOf<() -> Unit>()
 
     protected var lastFrame: Duration = now().milliseconds
     protected var dt: Duration = Duration.ZERO
@@ -116,7 +116,7 @@ abstract class Context {
      * Creates a new render callback is invoked on every frame.
      * @return a lambda that can be invoked to remove the callback
      */
-    open fun onRender(action: suspend (dt: Duration) -> Unit): RemoveContextCallback {
+    open fun onRender(action: (dt: Duration) -> Unit): RemoveContextCallback {
         renderCalls += action
         return {
             check(renderCalls.contains(action)) { "the 'onRender' action has already been removed!" }
@@ -128,7 +128,7 @@ abstract class Context {
      * Creates a new post-render callback that is invoked after the _render_ method is finished.
      * @return a lambda that can be invoked to remove the callback
      */
-    open fun onPostRender(action: suspend (dt: Duration) -> Unit): RemoveContextCallback {
+    open fun onPostRender(action: (dt: Duration) -> Unit): RemoveContextCallback {
         postRenderCalls += action
         return {
             check(postRenderCalls.contains(action)) { "the 'onPostRender' action has already been removed!" }
@@ -140,7 +140,7 @@ abstract class Context {
      * Creates a new _resize_ callback that is invoked whenever the context is resized.
      * @return a lambda that can be invoked to remove the callback
      */
-    open fun onResize(action: suspend (width: Int, height: Int) -> Unit): RemoveContextCallback {
+    open fun onResize(action: (width: Int, height: Int) -> Unit): RemoveContextCallback {
         resizeCalls += action
         return {
             check(resizeCalls.contains(action)) { "the 'onResize' action has already been removed!" }
@@ -164,7 +164,7 @@ abstract class Context {
      * Creates a new _postRunnable_ that is invoked one time after the next frame.
      * @return a lambda that can be invoked to remove the callback
      */
-    open fun postRunnable(action: suspend () -> Unit): RemoveContextCallback {
+    open fun postRunnable(action: () -> Unit): RemoveContextCallback {
         postRunnableCalls += action
         return {
             check(postRunnableCalls.contains(action)) { "the 'postRunnable' action has already been removed!" }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/Scene.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/Scene.kt
@@ -19,12 +19,12 @@ abstract class Scene(val context: Context) : Disposable {
     /**
      * Invoked on every render frame.
      */
-    open suspend fun Context.render(dt: Duration) = Unit
+    open fun Context.render(dt: Duration) = Unit
 
     /**
      * Invoked when a resize event occurs.
      */
-    open suspend fun Context.resize(width: Int, height: Int) = Unit
+    open fun Context.resize(width: Int, height: Int) = Unit
 
     /**
      * Invoked when this scene is hidden from view.

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLContext.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGLContext.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.w3c.dom.HTMLCanvasElement
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.ExperimentalTime
 
 /**
  * @author Colton Daily
@@ -59,54 +58,51 @@ class WebGLContext(override val configuration: JsConfiguration) : Context() {
         window.requestAnimationFrame(::render)
     }
 
-    @Suppress("EXPERIMENTAL_IS_NOT_ENABLED")
-    @OptIn(ExperimentalTime::class)
     private fun render(now: Double) {
-        KtScope.launch {
-            if (canvas.clientWidth != graphics.width ||
-                canvas.clientHeight != graphics.height
-            ) {
-                graphics._width = canvas.clientWidth
-                graphics._height = canvas.clientHeight
-                canvas.width = canvas.clientWidth
-                canvas.height = canvas.clientHeight
-                listener.run {
-                    resizeCalls.fastForEach { resize ->
-                        resize(
-                            graphics.width, graphics.height
-                        )
-                    }
+        if (canvas.clientWidth != graphics.width ||
+            canvas.clientHeight != graphics.height
+        ) {
+            graphics._width = canvas.clientWidth
+            graphics._height = canvas.clientHeight
+            canvas.width = canvas.clientWidth
+            canvas.height = canvas.clientHeight
+            listener.run {
+                resizeCalls.fastForEach { resize ->
+                    resize(
+                        graphics.width, graphics.height
+                    )
                 }
             }
-            stats.engineStats.resetPerFrameCounts()
-
-            invokeAnyRunnable()
-
-            calcFrameTimes(now.milliseconds)
-            Dispatchers.KT.executePending(available)
-
-            input.update()
-            stats.update(dt)
-
-            renderCalls.fastForEach { render ->
-                render(dt)
-            }
-
-            postRenderCalls.fastForEach { postRender ->
-                postRender(dt)
-            }
-
-            input.reset()
-
-            if (closed) {
-                destroy()
-            } else {
-                window.requestAnimationFrame(::render)
-            }
         }
+        stats.engineStats.resetPerFrameCounts()
+
+        invokeAnyRunnable()
+
+        calcFrameTimes(now.milliseconds)
+        Dispatchers.KT.executePending(available)
+
+        input.update()
+        stats.update(dt)
+
+        renderCalls.fastForEach { render ->
+            render(dt)
+        }
+
+        postRenderCalls.fastForEach { postRender ->
+            postRender(dt)
+        }
+
+        input.reset()
+
+        if (closed) {
+            destroy()
+        } else {
+            window.requestAnimationFrame(::render)
+        }
+
     }
 
-    private suspend fun invokeAnyRunnable() {
+    private fun invokeAnyRunnable() {
         if (postRunnableCalls.isNotEmpty()) {
             postRunnableCalls.fastForEach { postRunnable ->
                 postRunnable.invoke()

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglContext.kt
@@ -15,7 +15,6 @@ import com.lehaine.littlekt.input.LwjglInput
 import com.lehaine.littlekt.log.Logger
 import com.lehaine.littlekt.util.fastForEach
 import com.lehaine.littlekt.util.internal.now
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.lwjgl.glfw.Callbacks
 import org.lwjgl.glfw.GLFW
@@ -208,14 +207,12 @@ class LwjglContext(override val configuration: JvmConfiguration) : Context() {
             graphics._width = width
             graphics._height = height
 
-            KtScope.launch {
                 resizeCalls.fastForEach { resize ->
                     resize(
                         width,
                         height
                     )
                 }
-            }
         }
 
         listener.run { start() }
@@ -255,7 +252,7 @@ class LwjglContext(override val configuration: JvmConfiguration) : Context() {
         GLFW.glfwPollEvents()
     }
 
-    private suspend fun invokeAnyRunnable() {
+    private fun invokeAnyRunnable() {
         if (postRunnableCalls.isNotEmpty()) {
             postRunnableCalls.fastForEach { postRunnable ->
                 postRunnable.invoke()

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -717,7 +717,9 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
         var firstLoaded = true
         onRender { dt ->
             if (!assetProvider.fullyLoaded) {
-                assetProvider.update()
+                KtScope.launch {
+                    assetProvider.update()
+                }
                 return@onRender
             }
             gl.clear(ClearBufferMask.COLOR_BUFFER_BIT)

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/DisplayTest.kt
@@ -717,9 +717,7 @@ class DisplayTest(context: Context) : Game<Scene>(context) {
         var firstLoaded = true
         onRender { dt ->
             if (!assetProvider.fullyLoaded) {
-                KtScope.launch {
-                    assetProvider.update()
-                }
+                assetProvider.update()
                 return@onRender
             }
             gl.clear(ClearBufferMask.COLOR_BUFFER_BIT)


### PR DESCRIPTION
Causes breaking changes for any suspend function called in any of these methods.

The following are now non-suspending:
* `Context.onRender`
* `Context.onPostRender`
* `Context.onPostRunnable`
* `Context.onResize`
* `AssetProvider.update`