### PR TITLE
Fix incorrect coordinates calculation with nested CanvasLayers

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/SceneGraph.kt
@@ -516,6 +516,9 @@ open class SceneGraph<InputType>(
                     val event = inputEventPool.alloc().apply {
                         sceneX = tempVec.x
                         sceneY = tempVec.y
+                        overLast.canvas?.screenToCanvasCoordinates(tempVec)
+                        canvasX = tempVec.x
+                        canvasY = tempVec.y
                         overLast.toLocal(tempVec, tempVec)
                         localX = tempVec.x
                         localY = tempVec.y
@@ -1048,14 +1051,18 @@ open class SceneGraph<InputType>(
 
         if (overLast != null) {
             val event = inputEventPool.alloc().apply {
+                overLast.canvas?.screenToCanvasCoordinates(
+                    tempVec.set(
+                        screenX,
+                        screenY
+                    )
+                )
                 this.sceneX = sceneX
                 this.sceneY = sceneY
+                this.canvasX = tempVec.x
+                this.canvasY = tempVec.y
                 this.pointer = pointer
-                if (overLast.canvas == sceneCanvas) {
-                    overLast.toLocal(sceneX, sceneY, tempVec)
-                } else {
-
-                }
+                overLast.toLocal(sceneX, sceneY, tempVec)
                 localX = tempVec.x
                 localY = tempVec.y
                 type = InputEvent.Type.MOUSE_EXIT
@@ -1069,8 +1076,16 @@ open class SceneGraph<InputType>(
 
         if (over != null) {
             val event = inputEventPool.alloc().apply {
+                over.canvas?.screenToCanvasCoordinates(
+                    tempVec.set(
+                        screenX,
+                        screenY
+                    )
+                )
                 this.sceneX = sceneX
                 this.sceneY = sceneY
+                this.canvasX = tempVec.x
+                this.canvasY = tempVec.y
                 this.pointer = pointer
                 over.toLocal(sceneX, sceneY, tempVec)
                 localX = tempVec.x
@@ -1113,17 +1128,6 @@ open class SceneGraph<InputType>(
         return false
     }
 
-    private fun Node.propagateInput(event: InputEvent<InputType>): Boolean {
-        nodes.forEachReversed {
-            it.propagateInput(event)
-            if (event.handled) {
-                return true
-            }
-        }
-        callInput(event)
-        return event.handled
-    }
-
     private fun callUnhandledInput(event: InputEvent<InputType>): Boolean {
         root.nodes.forEachReversed {
             if (it.propagateUnhandledInput(event)) {
@@ -1131,17 +1135,6 @@ open class SceneGraph<InputType>(
             }
         }
         return false
-    }
-
-    private fun Node.propagateUnhandledInput(event: InputEvent<InputType>): Boolean {
-        nodes.forEachReversed {
-            it.propagateUnhandledInput(event)
-            if (event.handled) {
-                return true
-            }
-        }
-        callUnhandledInput(event)
-        return event.handled
     }
 
     fun screenToSceneCoordinates(inOut: MutableVec2f) = sceneCanvas.screenToCanvasCoordinates(inOut)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/CanvasItem.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/CanvasItem.kt
@@ -573,7 +573,7 @@ abstract class CanvasItem : Node() {
         if (!enabled || !insideTree || isDestroyed) return
 
         event.apply {
-            val localCoords = toLocal(event.sceneX, event.sceneY, tempVec)
+            val localCoords = toLocal(event.canvasX, event.canvasY, tempVec)
             localX = localCoords.x
             localY = localCoords.y
         }
@@ -588,7 +588,7 @@ abstract class CanvasItem : Node() {
         if (!enabled || !insideTree || isDestroyed) return
 
         event.apply {
-            val localCoords = toLocal(event.sceneX, event.sceneY, tempVec)
+            val localCoords = toLocal(event.canvasX, event.canvasY, tempVec)
             localX = localCoords.x
             localY = localCoords.y
         }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/Node.kt
@@ -556,6 +556,28 @@ open class Node : Comparable<Node> {
         return null
     }
 
+    open fun propagateInput(event: InputEvent<*>): Boolean {
+        nodes.forEachReversed {
+            it.propagateInput(event)
+            if (event.handled) {
+                return true
+            }
+        }
+        callInput(event)
+        return event.handled
+    }
+
+    open fun propagateUnhandledInput(event: InputEvent<*>): Boolean {
+        nodes.forEachReversed {
+            it.propagateUnhandledInput(event)
+            if (event.handled) {
+                return true
+            }
+        }
+        callUnhandledInput(event)
+        return event.handled
+    }
+
     open fun callInput(event: InputEvent<*>) {
         if (!enabled || !insideTree || isDestroyed) return
         onInput.emit(event)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/resource/InputEvent.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/resource/InputEvent.kt
@@ -14,9 +14,43 @@ class InputEvent<InputSignal> : Event() {
     var key: Key = Key.ANY_KEY
     var inputType: InputSignal? = null
     var char: Char = Char.MIN_VALUE
+
+    /**
+     * The x-coord of the root scene canvas. Changing this will also set [canvasX] automatically.
+     */
     var sceneX: Float = 0f
+        set(value) {
+            field = value
+            canvasX = value
+        }
+
+    /**
+     * The y-coord of the root scene canvas. Changing this will also set [canvasY] automatically.
+     */
     var sceneY: Float = 0f
+        set(value) {
+            field = value
+            canvasY = value
+        }
+
+    /**
+     * The x-coord of the current canvas. This may be equal to [sceneX] if there are no nested canvases.
+     */
+    var canvasX: Float = 0f
+
+    /**
+     * The y-coord of the current canvas. This may be equal to [sceneY] if there are no nested canvases.
+     */
+    var canvasY: Float = 0f
+
+    /**
+     * The x-coord of the current node in its local coordinates. (i.e a value of `0` will be the left edge)
+     */
     var localX: Float = 0f
+
+    /**
+     * The y-coord of the current node in its local coordinates. (i.e a value of `0` will be the top edge)
+     */
     var localY: Float = 0f
     var scrollAmountX: Float = 0f
     var scrollAmountY: Float = 0f
@@ -28,6 +62,8 @@ class InputEvent<InputSignal> : Event() {
         char = Char.MIN_VALUE
         sceneX = 0f
         sceneY = 0f
+        canvasX = 0f
+        canvasY = 0f
         localX = 0f
         localY = 0f
         scrollAmountX = 0f
@@ -36,7 +72,7 @@ class InputEvent<InputSignal> : Event() {
     }
 
     override fun toString(): String {
-        return "InputEvent(type=$type, pointer=$pointer, button=$button, keyCode=$key, sceneX=$sceneX, sceneY=$sceneY, scrollAmountX=$scrollAmountX, scrollAmountY=$scrollAmountY)"
+        return "InputEvent(type=$type, pointer=$pointer, button=$button, key=$key, inputType=$inputType, char=$char, sceneX=$sceneX, sceneY=$sceneY, canvasX=$canvasX, canvasY=$canvasY, localX=$localX, localY=$localY, scrollAmountX=$scrollAmountX, scrollAmountY=$scrollAmountY)"
     }
 
     enum class Type {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/BaseButton.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/BaseButton.kt
@@ -155,7 +155,7 @@ abstract class BaseButton : Control() {
             || event.type == InputEvent.Type.ACTION_UP && event.inputType == uiAccept
         ) {
             if (event.type == InputEvent.Type.ACTION_UP
-                || event.type == InputEvent.Type.TOUCH_UP && !hasPoint(event.sceneX, event.sceneY)
+                || event.type == InputEvent.Type.TOUCH_UP && !hasPoint(event.canvasX, event.canvasY)
             ) {
                 status.hovering = false
             }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/Control.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/Control.kt
@@ -609,7 +609,7 @@ open class Control : CanvasItem() {
         if (!enabled || !insideTree) return
 
         event.apply {
-            val localCoords = toLocal(event.sceneX, event.sceneY, tempVec2f)
+            val localCoords = toLocal(event.canvasX, event.canvasY, tempVec2f)
             localX = localCoords.x
             localY = localCoords.y
         }

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/LineEdit.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/LineEdit.kt
@@ -171,7 +171,7 @@ open class LineEdit : Control() {
 
         if (event.type == InputEvent.Type.TOUCH_DRAGGED) {
             if (lastPointer != event.pointer) return
-            pressed = hasPoint(event.sceneX, event.sceneY)
+            pressed = hasPoint(event.canvasX, event.canvasY)
             moveCaretToPosition(event.localX)
         }
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/ScrollContainer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graph/node/ui/ScrollContainer.kt
@@ -153,7 +153,7 @@ class ScrollContainer : Container(), GestureProcessor {
 
             InputEvent.Type.TOUCH_DOWN -> {
                 if (dragToScroll) {
-                    val result = gestureController.touchDown(event.sceneX, event.sceneY, event.pointer)
+                    val result = gestureController.touchDown(event.canvasX, event.canvasY, event.pointer)
                     if (result) {
                         event.handle()
                     }
@@ -162,7 +162,7 @@ class ScrollContainer : Container(), GestureProcessor {
 
             InputEvent.Type.TOUCH_DRAGGED -> {
                 if (dragToScroll) {
-                    val result = gestureController.touchDragged(event.sceneX, event.sceneY, event.pointer)
+                    val result = gestureController.touchDragged(event.canvasX, event.canvasY, event.pointer)
                     if (result) {
                         event.handle()
                     }
@@ -171,7 +171,7 @@ class ScrollContainer : Container(), GestureProcessor {
 
             InputEvent.Type.TOUCH_UP -> {
                 if (dragToScroll) {
-                    val result = gestureController.touchUp(event.sceneX, event.sceneY, event.pointer)
+                    val result = gestureController.touchUp(event.canvasX, event.canvasY, event.pointer)
                     if (result) {
                         event.handle()
                     }

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/CanvasCameraTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/CanvasCameraTest.kt
@@ -4,10 +4,10 @@ import com.lehaine.littlekt.Context
 import com.lehaine.littlekt.ContextListener
 import com.lehaine.littlekt.file.vfs.readBitmapFont
 import com.lehaine.littlekt.file.vfs.readTexture
-import com.lehaine.littlekt.graph.node.resource.HAlign
 import com.lehaine.littlekt.graph.node.frameBuffer
 import com.lehaine.littlekt.graph.node.node2d.camera2d
 import com.lehaine.littlekt.graph.node.node2d.node2d
+import com.lehaine.littlekt.graph.node.resource.HAlign
 import com.lehaine.littlekt.graph.node.ui.button
 import com.lehaine.littlekt.graph.node.ui.centerContainer
 import com.lehaine.littlekt.graph.node.ui.frameBufferContainer
@@ -102,6 +102,7 @@ class CanvasCameraTest(context: Context) : ContextListener(context) {
             println(it.sceneCanvas.treeString())
         }
 
+        graph.requestShowDebugInfo = true
         onResize { width, height ->
             graph.resize(width, height, true)
         }

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/SceneGraphNestedViewportsTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/SceneGraphNestedViewportsTest.kt
@@ -1,0 +1,104 @@
+package com.lehaine.littlekt.samples
+
+import com.lehaine.littlekt.Context
+import com.lehaine.littlekt.ContextListener
+import com.lehaine.littlekt.graph.node.ui.button
+import com.lehaine.littlekt.graph.node.ui.label
+import com.lehaine.littlekt.graph.node.viewport
+import com.lehaine.littlekt.graph.sceneGraph
+import com.lehaine.littlekt.graphics.gl.ClearBufferMask
+import com.lehaine.littlekt.input.Key
+import com.lehaine.littlekt.math.Vec2f
+import com.lehaine.littlekt.util.viewport.ExtendViewport
+
+/**
+ * @author Colton Daily
+ * @date 1/22/2023
+ */
+class SceneGraphNestedViewportsTest(context: Context) : ContextListener(context) {
+
+    override suspend fun Context.start() {
+        val graph = sceneGraph(context, ExtendViewport(960, 540)) {
+            viewport {
+                name = "Nested Viewport"
+                viewport = ExtendViewport(480, 270)
+                label {
+                    marginTop = 80f
+                    marginLeft = 5f
+                    name = "Nested"
+                    onInput += { event ->
+                        text =
+                            "$name: canvas coords: ${event.canvasX},${event.canvasY} local: ${event.localX},${event.localY}"
+                    }
+                }
+                button {
+                    marginTop = 100f
+                    marginLeft = 5f
+                    text = "Nested"
+                }
+
+                viewport {
+                    name = "Double Nested Viewport"
+                    viewport = ExtendViewport(240, 135)
+                    label {
+                        marginTop = 80f
+                        marginLeft = 5f
+                        name = "Double Nested"
+                        fontScale = Vec2f(0.5f)
+                        onInput += { event ->
+                            text =
+                                "$name: canvas coords: ${event.canvasX},${event.canvasY} local: ${event.localX},${event.localY}"
+                        }
+                    }
+
+                    button {
+                        marginTop = 100f
+                        marginLeft = 5f
+                        text = "Double nested"
+                    }
+                }
+            }
+
+            label {
+                marginTop = 10f
+                marginLeft = 10f
+                name = "Root"
+                onInput += { event ->
+                    text =
+                        "$name: canvas coords: ${event.canvasX},${event.canvasX} local: ${event.localX},${event.localY}"
+                }
+            }
+
+            button {
+                marginTop = 30f
+                marginLeft = 5f
+                text = "Root"
+            }
+
+        }
+        graph.initialize()
+        graph.requestShowDebugInfo = true
+
+        onResize { width, height ->
+            graph.resize(width, height, true)
+        }
+        onRender { dt ->
+            gl.clear(ClearBufferMask.COLOR_BUFFER_BIT)
+
+            graph.update(dt)
+            graph.render()
+
+            if (input.isKeyJustPressed(Key.P)) {
+                logger.info { stats }
+            }
+
+            if (input.isKeyJustPressed(Key.T)) {
+                println(graph.root.treeString())
+            }
+
+            if (input.isKeyJustPressed(Key.ESCAPE)) {
+                close()
+            }
+        }
+    }
+}

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/UiPlayground.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/UiPlayground.kt
@@ -510,7 +510,7 @@ class UiPlayground(context: Context) : ContextListener(context) {
             graph.render()
 
             if (input.isKeyJustPressed(Key.ENTER)) {
-                graph.showDebugInfo = !graph.showDebugInfo
+                graph.requestShowDebugInfo = !graph.requestShowDebugInfo
             }
 
             if (input.isKeyJustPressed(Key.R)) {

--- a/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/UiTest.kt
+++ b/samples/src/commonMain/kotlin/com/lehaine/littlekt/samples/UiTest.kt
@@ -95,7 +95,7 @@ class UiTest(context: Context) : ContextListener(context) {
             graph.render()
 
             if (input.isKeyJustPressed(Key.ENTER)) {
-                graph.showDebugInfo = !graph.showDebugInfo
+                graph.requestShowDebugInfo = !graph.requestShowDebugInfo
             }
 
             if (input.isKeyJustPressed(Key.T)) {

--- a/samples/src/jvmMain/kotlin/com/lehaine/littlekt/samples/SceneGraphNestedViewportsTest.kt
+++ b/samples/src/jvmMain/kotlin/com/lehaine/littlekt/samples/SceneGraphNestedViewportsTest.kt
@@ -1,0 +1,20 @@
+package com.lehaine.littlekt.samples
+
+import com.lehaine.littlekt.createLittleKtApp
+import com.lehaine.littlekt.graphics.Color
+
+/**
+ * @author Colton Daily
+ * @date 1/22/2023
+ */
+fun main(args: Array<String>) {
+    createLittleKtApp {
+        width = 960
+        height = 540
+        vSync = true
+        title = "JVM - Scene Graph Nested Viewports Test"
+        backgroundColor = Color.DARK_GRAY
+    }.start {
+        SceneGraphNestedViewportsTest(it)
+    }
+}


### PR DESCRIPTION
This includes all CanvasLayer subtypes such as FrameBufferNode & ViewportCanvasLayer.

Closes #204 