### PR TITLE
Add ability to reuse `GlFrameBuffer` and optimize `FrameBuffer` to not create a `GlFrameBuffer` object per `begin()` & `end()` call

### DIFF
--- a/core/src/androidMain/kotlin/com/lehaine/littlekt/AndroidGL.kt
+++ b/core/src/androidMain/kotlin/com/lehaine/littlekt/AndroidGL.kt
@@ -273,9 +273,9 @@ class AndroidGL(private val engineStats: EngineStats) : GL {
         GLES20.glGetIntegerv(pname, data.buffer)
     }
 
-    override fun getBoundFrameBuffer(data: IntBuffer): GlFrameBuffer {
+    override fun getBoundFrameBuffer(data: IntBuffer, out: GlFrameBuffer): GlFrameBuffer {
         getIntegerv(GL.FRAMEBUFFER_BINDING, data)
-        return GlFrameBuffer(data[0])
+        return out.apply { reference = data[0] }
     }
 
     override fun getShaderParameterB(glShader: GlShader, pname: Int): Boolean {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/FrameBuffer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/FrameBuffer.kt
@@ -86,6 +86,8 @@ open class FrameBuffer(
     private var depthStencilPackedBufferHandle: GlRenderBuffer? = null
 
     private var previousFboHandle: GlFrameBuffer? = null
+    private val tempFboHandle: GlFrameBuffer = GlFrameBuffer.EmptyGlFrameBuffer()
+    private val tempFboHandle2: GlFrameBuffer = GlFrameBuffer.EmptyGlFrameBuffer()
     private val previousViewport = MutableVec4i()
     private var isBound = false
     private var isPrepared = false
@@ -233,7 +235,7 @@ open class FrameBuffer(
         check(!isBound) { "end() must be called before another draw can begin." }
         isBound = true
 
-        previousFboHandle = getBoundFrameBuffer(gl)
+        previousFboHandle = getBoundFrameBuffer(gl, tempFboHandle)
         gl.bindFrameBuffer(fboHandle)
 
         getViewport(gl, previousViewport)
@@ -246,7 +248,7 @@ open class FrameBuffer(
         check(isBound) { "begin() must be called first!" }
 
         isBound = false
-        val currentFbo = getBoundFrameBuffer(gl)
+        val currentFbo = getBoundFrameBuffer(gl, tempFboHandle2)
         check(currentFbo == fboHandle) {
             "The current bound framebuffer ($currentFbo) doesn't match this one. " +
                     "Ensure that the frame buffers are closed in the same order they were opened in."
@@ -291,8 +293,8 @@ open class FrameBuffer(
          */
         private val intBuffer = createIntBuffer(16 * Int.SIZE_BYTES)
 
-        private fun getBoundFrameBuffer(gl: GL): GlFrameBuffer {
-            return gl.getBoundFrameBuffer(intBuffer)
+        private fun getBoundFrameBuffer(gl: GL, out: GlFrameBuffer): GlFrameBuffer {
+            return gl.getBoundFrameBuffer(intBuffer, out)
         }
 
         private fun getViewport(gl: GL, result: MutableVec4i) {

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/GL.kt
@@ -170,7 +170,7 @@ interface GL {
     fun bindDefaultRenderBuffer()
     fun renderBufferStorage(internalFormat: RenderBufferInternalFormat, width: Int, height: Int)
     fun frameBufferRenderBuffer(attachementType: FrameBufferRenderBufferAttachment, glRenderBuffer: GlRenderBuffer)
-    fun getBoundFrameBuffer(data: IntBuffer): GlFrameBuffer
+    fun getBoundFrameBuffer(data: IntBuffer, out: GlFrameBuffer = GlFrameBuffer.EmptyGlFrameBuffer()): GlFrameBuffer
     fun deleteFrameBuffer(glFrameBuffer: GlFrameBuffer)
     fun deleteRenderBuffer(glRenderBuffer: GlRenderBuffer)
     fun frameBufferTexture2D(attachementType: FrameBufferRenderBufferAttachment, glTexture: GlTexture, level: Int)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/gl/GlFrameBuffer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/gl/GlFrameBuffer.kt
@@ -4,4 +4,17 @@ package com.lehaine.littlekt.graphics.gl
  * @author Colton Daily
  * @date 9/28/2021
  */
-expect class GlFrameBuffer
+expect class GlFrameBuffer {
+    /**
+     * Copy another [GlFrameBuffer].
+     * @param glFrameBuffer the frame buffer to copy from
+     */
+    fun copy(glFrameBuffer: GlFrameBuffer): GlFrameBuffer
+
+    companion object {
+        /**
+         * Generate an empty [GlFrameBuffer].
+         */
+        fun EmptyGlFrameBuffer(): GlFrameBuffer
+    }
+}

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/WebGL.kt
@@ -327,10 +327,10 @@ class WebGL(
         }
     }
 
-    override fun getBoundFrameBuffer(data: IntBuffer): GlFrameBuffer {
+    override fun getBoundFrameBuffer(data: IntBuffer, out: GlFrameBuffer): GlFrameBuffer {
         engineStats.calls++
         val result = gl.getParameter(GL.FRAMEBUFFER_BINDING) as WebGLFramebuffer?
-        return GlFrameBuffer(result)
+        return out.apply { delegate = result }
     }
 
     override fun getProgramParameter(glShaderProgram: GlShaderProgram, pname: Int): Any {

--- a/core/src/jsMain/kotlin/com/lehaine/littlekt/graphics/gl/GlFrameBuffer.kt
+++ b/core/src/jsMain/kotlin/com/lehaine/littlekt/graphics/gl/GlFrameBuffer.kt
@@ -6,7 +6,15 @@ import org.khronos.webgl.WebGLFramebuffer
  * @author Colton Daily
  * @date 9/28/2021
  */
-actual class GlFrameBuffer(val delegate: WebGLFramebuffer?) {
+actual class GlFrameBuffer(var delegate: WebGLFramebuffer?) {
+    /**
+     * Copy another [GlFrameBuffer].
+     * @param glFrameBuffer the frame buffer to copy from
+     */
+    actual fun copy(glFrameBuffer: GlFrameBuffer): GlFrameBuffer {
+        delegate = glFrameBuffer.delegate
+        return this
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -14,9 +22,7 @@ actual class GlFrameBuffer(val delegate: WebGLFramebuffer?) {
 
         other as GlFrameBuffer
 
-        if (delegate != other.delegate) return false
-
-        return true
+        return delegate == other.delegate
     }
 
     override fun hashCode(): Int {
@@ -25,5 +31,12 @@ actual class GlFrameBuffer(val delegate: WebGLFramebuffer?) {
 
     override fun toString(): String {
         return "GlFrameBuffer(delegate=$delegate)"
+    }
+
+    actual companion object {
+        /**
+         * Generate an empty [GlFrameBuffer].
+         */
+        actual fun EmptyGlFrameBuffer(): GlFrameBuffer = GlFrameBuffer(null)
     }
 }

--- a/core/src/jvmAndroidMain/kotlin/com/lehaine/littlekt/graphics/gl/GlFrameBuffer.kt
+++ b/core/src/jvmAndroidMain/kotlin/com/lehaine/littlekt/graphics/gl/GlFrameBuffer.kt
@@ -4,7 +4,16 @@ package com.lehaine.littlekt.graphics.gl
  * @author Colton Daily
  * @date 9/28/2021
  */
-actual class GlFrameBuffer(val reference: Int) {
+actual class GlFrameBuffer(var reference: Int) {
+
+    /**
+     * Copy another [GlFrameBuffer].
+     * @param glFrameBuffer the frame buffer to copy from
+     */
+    actual fun copy(glFrameBuffer: GlFrameBuffer): GlFrameBuffer {
+        reference = glFrameBuffer.reference
+        return this
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -12,9 +21,7 @@ actual class GlFrameBuffer(val reference: Int) {
 
         other as GlFrameBuffer
 
-        if (reference != other.reference) return false
-
-        return true
+        return reference == other.reference
     }
 
     override fun hashCode(): Int {
@@ -25,4 +32,10 @@ actual class GlFrameBuffer(val reference: Int) {
         return "GlFrameBuffer(reference=$reference)"
     }
 
+    actual companion object {
+        /**
+         * Generate an empty [GlFrameBuffer].
+         */
+        actual fun EmptyGlFrameBuffer(): GlFrameBuffer = GlFrameBuffer(-1)
+    }
 }

--- a/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGL.kt
+++ b/core/src/jvmMain/kotlin/com/lehaine/littlekt/LwjglGL.kt
@@ -268,9 +268,9 @@ class LwjglGL(private val engineStats: EngineStats, private val graphics: Graphi
         glGetIntegerv(pname, data.buffer)
     }
 
-    override fun getBoundFrameBuffer(data: IntBuffer): GlFrameBuffer {
+    override fun getBoundFrameBuffer(data: IntBuffer, out: GlFrameBuffer): GlFrameBuffer {
         getIntegerv(GL.FRAMEBUFFER_BINDING, data)
-        return GlFrameBuffer(data[0])
+        return out.apply { reference = data[0] }
     }
 
     override fun getShaderParameterB(glShader: GlShader, pname: Int): Boolean {


### PR DESCRIPTION
fbo: add new GlFrameBuffer.EmptyGlFrameBuffer companion object function

gl: update GL.getBoundFrameBuffer to allow for optional 'out' param to prevent constant creation of new GlFrameBuffers

gl: update backend GlFrameBuffers to allow changing referene

fbo: optimze FrameBuffer to reuse GlFrameBuffer objects instead of creating new one on each begin() and end() call