### PR TITLE
Remove `ShaderProgram` `getAttrib()` and `getUniform()` from throwing an `IllegalStateException`

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/ShaderParameter.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/ShaderParameter.kt
@@ -33,7 +33,7 @@ sealed class ShaderParameter(val name: String) {
 
     class UniformMat3(name: String) : ShaderParameter(name) {
         fun apply(program: ShaderProgram<*, *>, matrix: Mat3) {
-            program.gl?.uniformMatrix3fv(program.getUniform(name), false, matrix)
+            program.getUniform(name)?.let { program.gl?.uniformMatrix3fv(it, false, matrix) }
         }
     }
 
@@ -52,13 +52,13 @@ sealed class ShaderParameter(val name: String) {
                     tmpMatrix[x * 16 + y] = mat.data[y]
                 }
             }
-            program.gl?.uniformMatrix3fv(program.getUniform(name), false, tmpMatrix)
+            program.getUniform(name)?.let { program.gl?.uniformMatrix3fv(it, false, tmpMatrix) }
         }
     }
 
     class UniformMat4(name: String) : ShaderParameter(name) {
         fun apply(program: ShaderProgram<*, *>, matrix: Mat4) {
-            program.gl?.uniformMatrix4fv(program.getUniform(name), false, matrix)
+            program.getUniform(name)?.let { program.gl?.uniformMatrix4fv(it, false, matrix) }
         }
     }
 
@@ -78,7 +78,7 @@ sealed class ShaderParameter(val name: String) {
                     tmpMatrix[x * 16 + y] = mat.data[y]
                 }
             }
-            program.gl?.uniformMatrix4fv(program.getUniform(name), false, tmpMatrix)
+            program.getUniform(name)?.let { program.gl?.uniformMatrix4fv(it, false, tmpMatrix) }
         }
     }
 
@@ -87,9 +87,9 @@ sealed class ShaderParameter(val name: String) {
         fun apply(program: ShaderProgram<*, *>, vararg value: Int) {
             when (value.size) {
                 0 -> throw IllegalArgumentException("At least one int is expected")
-                1 -> program.gl?.uniform1i(program.getUniform(name), value[0])
-                2 -> program.gl?.uniform2i(program.getUniform(name), value[0], value[1])
-                3 -> program.gl?.uniform3i(program.getUniform(name), value[0], value[1], value[2])
+                1 -> program.getUniform(name)?.let { program.gl?.uniform1i(it, value[0]) }
+                2 -> program.getUniform(name)?.let { program.gl?.uniform2i(it, value[0], value[1]) }
+                3 -> program.getUniform(name)?.let { program.gl?.uniform3i(it, value[0], value[1], value[2]) }
             }
         }
     }
@@ -100,7 +100,7 @@ sealed class ShaderParameter(val name: String) {
 
         fun apply(program: ShaderProgram<*, *>, vararg vec2: Float) {
             when (vec2.size) {
-                2 -> program.gl?.uniform2f(program.getUniform(name), vec2[0], vec2[1])
+                2 -> program.getUniform(name)?.let { program.gl?.uniform2f(it, vec2[0], vec2[1]) }
                 else -> throw IllegalArgumentException("3 values are expected. ${vec2.size} received")
             }
         }
@@ -112,7 +112,7 @@ sealed class ShaderParameter(val name: String) {
 
         fun apply(program: ShaderProgram<*, *>, vararg vec3: Float) {
             when (vec3.size) {
-                3 -> program.gl?.uniform3f(program.getUniform(name), vec3[0], vec3[1], vec3[2])
+                3 -> program.getUniform(name)?.let { program.gl?.uniform3f(it, vec3[0], vec3[1], vec3[2]) }
                 else -> throw IllegalArgumentException("3 values are expected. ${vec3.size} received")
             }
         }
@@ -138,7 +138,7 @@ sealed class ShaderParameter(val name: String) {
 
         fun apply(program: ShaderProgram<*, *>, vararg vec4: Float) {
             when (vec4.size) {
-                4 -> program.gl?.uniform4f(program.getUniform(name), vec4[0], vec4[1], vec4[2], vec4[3])
+                4 -> program.getUniform(name)?.let { program.gl?.uniform4f(it, vec4[0], vec4[1], vec4[2], vec4[3]) }
                 else -> throw IllegalArgumentException("4 values are expected. ${vec4.size} received")
             }
         }
@@ -149,10 +149,10 @@ sealed class ShaderParameter(val name: String) {
         fun apply(program: ShaderProgram<*, *>, vararg value: Float) {
             when (value.size) {
                 0 -> throw IllegalArgumentException("At least one int is expected")
-                1 -> program.gl?.uniform1f(program.getUniform(name), value[0])
-                2 -> program.gl?.uniform2f(program.getUniform(name), value[0], value[1])
-                3 -> program.gl?.uniform3f(program.getUniform(name), value[0], value[1], value[2])
-                4 -> program.gl?.uniform4f(program.getUniform(name), value[0], value[1], value[2], value[3])
+                1 -> program.getUniform(name)?.let { program.gl?.uniform1f(it, value[0]) }
+                2 -> program.getUniform(name)?.let { program.gl?.uniform2f(it, value[0], value[1]) }
+                3 -> program.getUniform(name)?.let { program.gl?.uniform3f(it, value[0], value[1], value[2]) }
+                4 -> program.getUniform(name)?.let { program.gl?.uniform4f(it, value[0], value[1], value[2], value[3]) }
             }
         }
     }
@@ -160,11 +160,11 @@ sealed class ShaderParameter(val name: String) {
     class UniformArrayFloat(name: String) : ShaderParameter(name) {
 
         fun apply(program: ShaderProgram<*, *>, f: Array<Float>) {
-            program.gl?.uniform1fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform1fv(it, f) }
         }
 
         fun apply(program: ShaderProgram<*, *>, f: FloatArray) {
-            program.gl?.uniform1fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform1fv(it, f) }
         }
 
         fun apply(program: ShaderProgram<*, *>, f: List<Float>) = apply(program, f.toTypedArray())
@@ -173,11 +173,11 @@ sealed class ShaderParameter(val name: String) {
     class UniformArrayVec2(name: String) : ShaderParameter(name) {
 
         fun apply(program: ShaderProgram<*, *>, f: Array<Float>) {
-            program.gl?.uniform2fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform2fv(it, f) }
         }
 
         fun apply(program: ShaderProgram<*, *>, f: FloatArray) {
-            program.gl?.uniform2fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform2fv(it, f) }
         }
 
         fun apply(program: ShaderProgram<*, *>, f: List<Float>) = apply(program, f.toTypedArray())
@@ -187,12 +187,12 @@ sealed class ShaderParameter(val name: String) {
 
         @JvmName("applyArray")
         fun apply(program: ShaderProgram<*, *>, f: Array<Float>) {
-            program.gl?.uniform3fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform3fv(it, f) }
         }
 
         @JvmName("applyArray")
         fun apply(program: ShaderProgram<*, *>, f: FloatArray) {
-            program.gl?.uniform3fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform3fv(it, f) }
         }
 
         fun apply(program: ShaderProgram<*, *>, f: List<Float>) = apply(program, f.toTypedArray())
@@ -202,12 +202,12 @@ sealed class ShaderParameter(val name: String) {
 
         @JvmName("applyArray")
         fun apply(program: ShaderProgram<*, *>, f: Array<Float>) {
-            program.gl?.uniform4fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform4fv(it, f) }
         }
 
         @JvmName("applyArray")
         fun apply(program: ShaderProgram<*, *>, f: FloatArray) {
-            program.gl?.uniform4fv(program.getUniform(name), f)
+            program.getUniform(name)?.let { program.gl?.uniform4fv(it, f) }
         }
 
         @JvmName("applyColors")
@@ -224,18 +224,18 @@ sealed class ShaderParameter(val name: String) {
         fun apply(program: ShaderProgram<*, *>, glTexture: GlTexture, unit: Int = 0) {
             program.gl?.activeTexture(GL.TEXTURE0 + unit)
             program.gl?.bindTexture(TextureTarget._2D, glTexture)
-            program.gl?.uniform1i(program.getUniform(name), unit)
+            program.getUniform(name)?.let { program.gl?.uniform1i(it, unit) }
         }
 
         fun apply(program: ShaderProgram<*, *>, unit: Int = 0) {
-            program.gl?.uniform1i(program.getUniform(name), unit)
+            program.getUniform(name)?.let { program.gl?.uniform1i(it, unit) }
         }
     }
 
     class UniformBoolean(name: String) : ShaderParameter(name) {
 
         fun apply(program: ShaderProgram<*, *>, value: Boolean) {
-            program.gl?.uniform1i(program.getUniform(name), if (value) 1 else 0)
+            program.getUniform(name)?.let { program.gl?.uniform1i(it, if (value) 1 else 0) }
         }
     }
 

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/ShaderProgram.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/shader/ShaderProgram.kt
@@ -51,7 +51,10 @@ class ShaderProgram<V : VertexShader, F : FragmentShader>(
 
     private var isPrepared = false
 
-
+    /**
+     * Generates the source for each shader and compiles them. A shader program is created, the shaders attached,
+     * and the program linked. Lastly, the uniforms and attributes are fetched.
+     */
     override fun prepare(context: Context) {
         val gl = context.gl.also { gl = it }
         if (vertexShader is VertexShaderModel) {
@@ -131,27 +134,24 @@ class ShaderProgram<V : VertexShader, F : FragmentShader>(
         }
     }
 
-    fun createAttrib(name: String) {
-        val gl = gl
-        val programGl = programGl
-        check(isPrepared && programGl != null && gl != null) { "ShaderProgram is not prepared! Make sure to call prepare(context)." }
-        attributes[name] = gl.getAttribLocation(programGl, name)
-    }
-
-    fun createUniform(name: String) {
-        val gl = gl
-        val programGl = programGl
-        check(isPrepared && programGl != null && gl != null) { "ShaderProgram is not prepared! Make sure to call prepare(context)." }
-        uniforms[name] = gl.getUniformLocation(programGl, name)
-    }
-
+    /**
+     * @param name the name of the attribute
+     * @return the attribute location if it exists; `-1` otherwise
+     */
     fun getAttrib(name: String): Int =
-        attributes[name] ?: throw IllegalStateException("Attributes '$name' not created!")
+        attributes[name] ?: -1
 
-    fun getUniform(name: String): UniformLocation {
-        return uniforms[name] ?: throw IllegalStateException("Uniform '$name' not created!")
+    /**
+     * @param name the name of the uniform
+     * @return the [UniformLocation] if it exists; `null` otherwise
+     */
+    fun getUniform(name: String): UniformLocation? {
+        return uniforms[name]
     }
 
+    /**
+     * Binds the shader program after it has been prepared.
+     */
     fun bind() {
         val gl = gl
         val programGl = programGl


### PR DESCRIPTION
`ShaderProgram.getAttrib()` will now return a `-1` if the attribute doesn't exist in the list.
`ShaderProgram.getUniform()` will now return a `null` if the `UniformLocation` doesn't exist.