### PR TITLE
Add more collision functions to Rect()

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/math/Rect.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/math/Rect.kt
@@ -59,6 +59,7 @@ open class Rect(var x: Float = 0f, var y: Float = 0f, var width: Float = 0f, var
 
     /**
      * Returns all of the Rect()s that intersect with this rect.
+     * @return List<Rect>
      */
     fun getIntersectingRects(list: List<Rect>): List<Rect> {
         var rectsFound = mutableListOf<Rect>()
@@ -70,7 +71,7 @@ open class Rect(var x: Float = 0f, var y: Float = 0f, var width: Float = 0f, var
 
     /**
      * You pass in a Map of <T, Rect> and it returns the keys
-     * of any rects that intersect with this one.
+     * of any rects that intersect with this one. (in a List())
      */
     fun <T> getIntersectingRectIds(rects:Map<T,Rect>):List<T> {
         var idsFound = mutableListOf<T>()

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/math/Rect.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/math/Rect.kt
@@ -36,10 +36,41 @@ open class Rect(var x: Float = 0f, var y: Float = 0f, var width: Float = 0f, var
         return true
     }
 
+    /**
+     * Returns true if all of the Rect()s in the list intersect with this rect
+     */
+    fun intersectsListAll(list: List<Rect>): Boolean {
+        for(rect in list) {
+            if(!this.intersects(rect)) { return false }
+        }
+        return true
+    }
+
+    /**
+     * Returns true if any of the rectangles intersect with this one.
+     */
+    fun intersectsListAny(list: List<Rect>): Boolean {
+        var foundIntersection = false
+        for(rect in list) {
+            if(this.intersects(rect)) { foundIntersection = true }
+        }
+        return foundIntersection
+    }
+
+    /**
+     * Returns all of the Rect()s that intersect with this rect.
+     */
+    fun getIntersectingRects(list: List<Rect>): List<Rect> {
+        var rectsFound = mutableListOf<Rect>()
+        for(rect in list) {
+            if(this.intersects(rect)) { rectsFound += rect }
+        }
+        return rectsFound
+    }
+
     override fun toString(): String {
         return "Rect(x=$x, y=$y, width=$width, height=$height, x2=$x2, y2=$y2)"
     }
-
 
     companion object {
         fun fromBounds(x: Float, y: Float, x2: Float, y2: Float) = Rect(x, y, x2 - x, y2 - y)

--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/math/Rect.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/math/Rect.kt
@@ -68,6 +68,20 @@ open class Rect(var x: Float = 0f, var y: Float = 0f, var width: Float = 0f, var
         return rectsFound
     }
 
+    /**
+     * You pass in a Map of <T, Rect> and it returns the keys
+     * of any rects that intersect with this one.
+     */
+    fun <T> getIntersectingRectIds(rects:Map<T,Rect>):List<T> {
+        var idsFound = mutableListOf<T>()
+        for(key in rects.keys) {
+            if(rects[key]?.let { intersects(it) } == true) {
+                idsFound += key
+            }
+        }
+        return idsFound
+    }
+
     override fun toString(): String {
         return "Rect(x=$x, y=$y, width=$width, height=$height, x2=$x2, y2=$y2)"
     }

--- a/core/src/commonTest/kotlin/com.lehaine.littlekt.math/TestRect.kt
+++ b/core/src/commonTest/kotlin/com.lehaine.littlekt.math/TestRect.kt
@@ -32,6 +32,10 @@ class TestRect {
     }
 
     @Test
+    // For some reason JUnit was treating two identical Rect()s as different,
+    // so I'm using the amount of intersecting rects returned.
+    // The first check has one intersecting, and one not intersecting,
+    // while the second check has both intersecting.
     fun TestGetIntersectingRects() {
         expect(1) {
             Rect(0f, 0f, 10f, 10f).getIntersectingRects(listOf(

--- a/core/src/commonTest/kotlin/com.lehaine.littlekt.math/TestRect.kt
+++ b/core/src/commonTest/kotlin/com.lehaine.littlekt.math/TestRect.kt
@@ -49,5 +49,18 @@ class TestRect {
                 Rect(2f, 2f, 10f, 10f)
             )).size
         }
+
+
+
+    }
+
+    @Test
+    fun TestGetIntersectingRectIds() {
+        val result = Rect(0f, 0f, 10f, 10f).getIntersectingRectIds(mapOf(
+            "hi" to Rect(1f, 1f, 10f, 10f),
+            "hi2" to Rect(11f, 11f, 10f, 10f)
+        ))
+        expect(true) { result.contains("hi") }
+        expect(false) { result.contains("hi2") }
     }
 }

--- a/core/src/commonTest/kotlin/com.lehaine.littlekt.math/TestRect.kt
+++ b/core/src/commonTest/kotlin/com.lehaine.littlekt.math/TestRect.kt
@@ -1,0 +1,49 @@
+package com.lehaine.littlekt.math
+
+import kotlin.test.Test
+import kotlin.test.expect
+
+class TestRect {
+    @Test
+    fun TestIntersects() {
+        expect(true) {
+            Rect(0f, 0f, 10f, 10f).intersects(Rect(1f, 1f, 10f, 10f))
+        }
+    }
+
+    @Test
+    fun TestIntersectsListAll() {
+        expect(true) {
+            Rect(0f, 0f, 10f, 10f).intersectsListAll(listOf(
+                Rect(1f, 1f, 10f, 10f),
+                Rect(2f, 2f, 10f, 10f)
+            ))
+        }
+    }
+
+    @Test
+    fun TestIntersectsListAny() {
+        expect(true) {
+            Rect(0f, 0f, 10f, 10f).intersectsListAny(listOf(
+                Rect(1f, 1f, 10f, 10f),
+                Rect(11f, 11f, 10f, 10f)
+            ))
+        }
+    }
+
+    @Test
+    fun TestGetIntersectingRects() {
+        expect(1) {
+            Rect(0f, 0f, 10f, 10f).getIntersectingRects(listOf(
+                Rect(1f, 1f, 10f, 10f),
+                Rect(11f, 11f, 10f, 10f) // This does not intersect
+            )).size
+        }
+        expect(2) {
+            Rect(0f, 0f, 10f, 10f).getIntersectingRects(listOf(
+                Rect(1f, 1f, 10f, 10f),
+                Rect(2f, 2f, 10f, 10f)
+            )).size
+        }
+    }
+}


### PR DESCRIPTION
I added some more collision functions to Rect() that I would find useful that handle things like colliding with multiple rectangles in a list, and a function that takes in a Map<T, Rect> and spits out a list of the keys of the rectangles that intersect. I hope that other people will find these useful, and that I haven't screwed up! (This is probably my first **real** contribution to a repo besides my own)