### PR TITLE
Make tiles public

### DIFF
--- a/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/g2d/tilemap/tiled/TiledTilesLayer.kt
+++ b/core/src/commonMain/kotlin/com/lehaine/littlekt/graphics/g2d/tilemap/tiled/TiledTilesLayer.kt
@@ -35,7 +35,7 @@ class TiledTilesLayer(
     private val staggerAxis: TiledMap.StaggerAxis?,
     private val orientation: TiledMap.Orientation,
     private val tileData: IntArray,
-    private val tiles: Map<Int, TiledTileset.Tile>,
+    val tiles: Map<Int, TiledTileset.Tile>,
 ) : TiledLayer(
     type, name, id, visible, width, height, offsetX, offsetY, tileWidth, tileHeight, tintColor, opacity, properties
 ) {


### PR DESCRIPTION
As in #240, make tiles public so that I can access a list of the co-ordinates of every tile that has been placed in a layer.