### PR TITLE
scene-graph: update SceneGraph to only set sceneCanvas Node spriteShader to the Batch.defaultShader, if it owns the batch, otherwise it will create a new Shader

### DIFF
--- a/core/src/commonMain/kotlin/com/littlekt/util/viewport/ViewportExt.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/util/viewport/ViewportExt.kt
@@ -2,6 +2,12 @@ package com.littlekt.util.viewport
 
 import com.littlekt.graphics.webgpu.RenderPassEncoder
 
+/**
+ * Sets the viewport used during the rasterization stage to linear map from normalized device
+ * coordinates to viewport coordinates.
+ *
+ * @param viewport viewport data use on the render pass
+ */
 fun RenderPassEncoder.setViewport(viewport: Viewport) {
     setViewport(viewport.x, viewport.y, viewport.width, viewport.height)
 }

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/GameWorldAndUIViewports.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/GameWorldAndUIViewports.kt
@@ -1,0 +1,148 @@
+package com.littlekt.examples
+
+import com.littlekt.Context
+import com.littlekt.ContextListener
+import com.littlekt.file.vfs.readLDtkMapLoader
+import com.littlekt.graph.node.ui.centerContainer
+import com.littlekt.graph.node.ui.label
+import com.littlekt.graph.sceneGraph
+import com.littlekt.graphics.g2d.SpriteBatch
+import com.littlekt.graphics.webgpu.*
+import com.littlekt.util.viewport.ExtendViewport
+import com.littlekt.util.viewport.setViewport
+
+/**
+ * An example using a render pass for the game world and a render pass for the UI.
+ *
+ * @author Colton Daily
+ * @date 5/2/2024
+ */
+class GameWorldAndUIViewports(context: Context) : ContextListener(context) {
+
+    override suspend fun Context.start() {
+        addStatsHandler()
+        addCloseOnEsc()
+        val device = graphics.device
+        val mapLoader = resourcesVfs["ldtk/world-1.5.3.ldtk"].readLDtkMapLoader()
+        // we are only loading the first level
+        // we can load additional levels by doing:
+        // mapLoader.loadLevel(levelIdx)
+        val world = mapLoader.loadMap(false, 0)
+        val surfaceCapabilities = graphics.surfaceCapabilities
+        val preferredFormat = graphics.preferredFormat
+
+        graphics.configureSurface(
+            TextureUsage.RENDER_ATTACHMENT,
+            preferredFormat,
+            PresentMode.FIFO,
+            surfaceCapabilities.alphaModes[0]
+        )
+
+        val batch = SpriteBatch(device, graphics, preferredFormat, size = 400)
+        val worldViewport = ExtendViewport(270, 135)
+        val worldCamera = worldViewport.camera
+        addWASDMovement(worldCamera, 0.05f)
+        val bgColor =
+            if (preferredFormat.srgb) world.defaultLevelBackgroundColor.toLinear()
+            else world.defaultLevelBackgroundColor
+        val graph =
+            sceneGraph(this, ExtendViewport(480, 270), batch = batch) {
+                    centerContainer {
+                        anchorRight = 1f
+                        anchorTop = 1f
+                        label { text = "This is my UI!" }
+                    }
+                }
+                .also { it.initialize() }
+
+        graph.requestShowDebugInfo = true
+        onResize { width, height ->
+            graph.resize(width, height)
+            worldViewport.update(width, height)
+            graphics.configureSurface(
+                TextureUsage.RENDER_ATTACHMENT,
+                preferredFormat,
+                PresentMode.FIFO,
+                surfaceCapabilities.alphaModes[0]
+            )
+        }
+
+        onUpdate { dt ->
+            val surfaceTexture = graphics.surface.getCurrentTexture()
+            when (val status = surfaceTexture.status) {
+                TextureStatus.SUCCESS -> {
+                    // all good, could check for `surfaceTexture.suboptimal` here.
+                }
+                TextureStatus.TIMEOUT,
+                TextureStatus.OUTDATED,
+                TextureStatus.LOST -> {
+                    surfaceTexture.texture?.release()
+                    logger.info { "getCurrentTexture status=$status" }
+                    return@onUpdate
+                }
+                else -> {
+                    // fatal
+                    logger.fatal { "getCurrentTexture status=$status" }
+                    close()
+                    return@onUpdate
+                }
+            }
+            val swapChainTexture = checkNotNull(surfaceTexture.texture)
+            val frame = swapChainTexture.createView()
+
+            val commandEncoder = device.createCommandEncoder("command encoder")
+
+            val worldRenderPass =
+                commandEncoder.beginRenderPass(
+                    desc =
+                        RenderPassDescriptor(
+                            listOf(
+                                RenderPassColorAttachmentDescriptor(
+                                    view = frame,
+                                    loadOp = LoadOp.CLEAR,
+                                    storeOp = StoreOp.STORE,
+                                    clearColor = bgColor
+                                )
+                            )
+                        )
+                )
+            worldRenderPass.setViewport(worldViewport)
+            worldCamera.update()
+
+            batch.begin()
+            world.render(batch, worldCamera, scale = 1f)
+            batch.flush(worldRenderPass, worldCamera.viewProjection)
+
+            worldRenderPass.end()
+            worldRenderPass.release()
+
+            val uiRenderPassDescriptor =
+                RenderPassDescriptor(
+                    listOf(
+                        RenderPassColorAttachmentDescriptor(
+                            view = frame,
+                            loadOp = LoadOp.LOAD,
+                            storeOp = StoreOp.STORE
+                        )
+                    ),
+                    label = "Init render pass"
+                )
+
+            graph.update(dt)
+            graph.render(commandEncoder, uiRenderPassDescriptor)
+            batch.end()
+
+            val commandBuffer = commandEncoder.finish()
+
+            device.queue.submit(commandBuffer)
+            graphics.surface.present()
+
+            commandBuffer.release()
+            commandEncoder.release()
+            frame.release()
+            swapChainTexture.release()
+        }
+
+        onRelease { batch.release() }
+    }
+}

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/RunnerUtils.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/RunnerUtils.kt
@@ -22,5 +22,6 @@ val availableExamples =
         "-font" to Pair("Font", ::FontExample),
         "-helloSceneGraph" to Pair("Hello Scene Graph", ::HelloSceneGraphExample),
         "-renderTarget" to Pair("Render Target", ::RenderTargetExample),
-        "-computeBoids" to Pair("Compute Boids", ::ComputeBoidsExample)
+        "-computeBoids" to Pair("Compute Boids", ::ComputeBoidsExample),
+        "-worldAndUiViewports" to Pair("Game World and UI Viewports", ::GameWorldAndUIViewports)
     )

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/SceneGraph.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/SceneGraph.kt
@@ -184,14 +184,16 @@ open class SceneGraph<InputType>(
     val shapeRenderer: ShapeRenderer = ShapeRenderer(this.batch, whitePixel)
 
     /**
-     * The root [ViewportCanvasLayer] that is used for rendering all the children in the graph. Do
-     * not add children directly to this node. Instead, add children to the [root] node.
+     * The root [CanvasLayer] that is used for rendering all the children in the graph. Do not add
+     * children directly to this node. Instead, add children to the [root] node.
      */
     val sceneCanvas: CanvasLayer by lazy {
         CanvasLayer().apply {
             name = "Scene Viewport"
             this.viewport = viewport
-            spriteShader = this@SceneGraph.batch.defaultShader
+            if (ownsBatch) {
+                spriteShader = this@SceneGraph.batch.defaultShader
+            }
             resizeAutomatically = false
         }
     }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/CanvasLayer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/CanvasLayer.kt
@@ -71,7 +71,7 @@ open class CanvasLayer : Node() {
      * Viewport instance that can be used for rendering children nodes in inherited classes. This is
      * not used directly in the base [CanvasLayer] class.
      *
-     * @see ViewportCanvasLayer
+     * @see CanvasLayerContainer
      */
     var viewport: Viewport = Viewport()
 


### PR DESCRIPTION
Adds new `GameWorldAndUIViewportsExample`.