### PR TITLE
core: update TextureAtlas to flip the offsetY coord, when parsing, to be relative to the bottom of the image rather than the top

### DIFF
--- a/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/SpriteBatch.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/SpriteBatch.kt
@@ -160,7 +160,7 @@ class SpriteBatch(
         ensureDrawCall(slice.texture)
 
         var fx = -(originX - slice.offsetX)
-        var fy = -originY
+        var fy = -(originY - slice.offsetY)
         val w = if (slice.rotated) height else width
         val h = if (slice.rotated) width else height
         var fx2 = w + fx
@@ -292,7 +292,7 @@ class SpriteBatch(
         ensureDrawCall(slice.texture)
 
         var fx = -(originX - slice.offsetX)
-        var fy = -originY
+        var fy = -(originY - slice.offsetY)
         val w = if (slice.rotated) height else width
         val h = if (slice.rotated) width else height
         var fx2 = w + fx

--- a/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/TextureAtlas.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/TextureAtlas.kt
@@ -25,6 +25,7 @@ internal constructor(private val textures: Map<String, Texture>, info: AtlasInfo
             .flatMap { page -> page.frames.map { frame -> Entry(frame, page) } }
             .sortedWith { o1, o2 -> o1.name.compareName(o2.name) }
 
+    /** A map of all [entries] in the atlas, associated by its name. */
     val entriesMap = entries.associateBy { it.name }
 
     /**
@@ -51,12 +52,14 @@ internal constructor(private val textures: Map<String, Texture>, info: AtlasInfo
                         virtualFrame =
                             Rect(
                                 frame.spriteSourceSize.x.toFloat(),
-                                frame.spriteSourceSize.y.toFloat(),
+                                frame.sourceSize.h -
+                                    frame.frame.h -
+                                    frame.spriteSourceSize.y.toFloat(),
                                 frame.spriteSourceSize.w.toFloat(),
                                 frame.spriteSourceSize.h.toFloat()
                             )
-                        originalWidth = frame.sourceSize.w
-                        originalHeight = frame.sourceSize.h
+                        actualWidth = frame.sourceSize.w
+                        actualHeight = frame.sourceSize.h
                     }
                 }
         val name

--- a/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/TextureSlice.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/TextureSlice.kt
@@ -122,29 +122,45 @@ open class TextureSlice(
     val isFlipV: Boolean
         get() = v > v1
 
+    /** The virtual drawing frame of the trimmed image, if applicable. */
     var virtualFrame: Rect? = null
 
+    /**
+     * The offset from the left of the unpacked image to the left of the packed image after
+     * whitespace was trimmed.
+     */
     val offsetX: Int
         get() = virtualFrame?.x?.toInt() ?: 0
 
+    /**
+     * The offset from the bottom of the unpacked image to the bottom of the packed image after
+     * whitespace was removed.
+     */
     val offsetY: Int
         get() = virtualFrame?.y?.toInt() ?: 0
 
-    val packedWidth: Int
+    /** The width after whitespace was trimmed. */
+    val trimmedWidth: Int
         get() = virtualFrame?.width?.toInt() ?: width
 
-    val packedHeight: Int
+    /** The height after whitespace was trimmed. */
+    val trimmedHeight: Int
         get() = virtualFrame?.height?.toInt() ?: height
 
-    var originalWidth: Int = abs(width)
-    var originalHeight: Int = abs(height)
+    /** The width before whitespace was trimmed. */
+    var actualWidth: Int = abs(width)
 
+    /** The height before whitespace was trimmed. */
+    var actualHeight: Int = abs(height)
+
+    /** if true, indicates this slice was rotated 90 degrees CCW. */
     var rotated: Boolean = false
 
     init {
         setSlice(x, y, width, height)
     }
 
+    /** Set this slice's UV coordinates and width / height based on the region specified. */
     fun setSlice(x: Int, y: Int, width: Int, height: Int) {
         val invTexWidth = 1f / texture.width
         val invTexHeight = 1f / texture.height
@@ -158,6 +174,9 @@ open class TextureSlice(
         this.height = abs(height)
     }
 
+    /**
+     * Set this slice's UV coordinates. Width & height will be calculated from the new coordinates.
+     */
     fun setSlice(u: Float, v: Float, u2: Float, v2: Float) {
         width = (abs(u2 - u) * texture.width).roundToInt()
         height = (abs(v2 - v) * texture.height).roundToInt()
@@ -168,22 +187,29 @@ open class TextureSlice(
         this.v1 = v2
     }
 
+    /** Set this slice to match the specified [slice] coordinates. */
     fun setSlice(slice: TextureSlice) {
         texture = slice.texture
         setSlice(slice.u, slice.v, slice.u1, slice.v1)
     }
 
+    /**
+     * Set this slice to match the specified [slice] coordinates plus an additional offset and using
+     * specified size.
+     */
     fun setSlice(slice: TextureSlice, x: Int, y: Int, width: Int, height: Int) {
         texture = slice.texture
         setSlice(slice.x + x, slice.y + y, width, height)
     }
 
+    /** Flip the UV coordinates horizontally. */
     fun flipH() {
         val temp = u
         u = u1
         u1 = temp
     }
 
+    /** Flip the UV coordinates vertically. */
     fun flipV() {
         val temp = v
         v = v1

--- a/core/src/commonMain/kotlin/com/littlekt/util/MutableTextureAtlas.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/util/MutableTextureAtlas.kt
@@ -89,15 +89,15 @@ class MutableTextureAtlas(val context: Context, options: PackingOptions = Packin
                         it.isRotated,
                         slice.offsetX != 0 ||
                             slice.offsetY != 0 ||
-                            slice.packedWidth != slice.width ||
-                            slice.packedHeight != slice.height,
+                            slice.trimmedWidth != slice.width ||
+                            slice.trimmedHeight != slice.height,
                         AtlasPage.Rect(
                             slice.offsetX,
                             slice.offsetY,
-                            slice.packedWidth,
-                            slice.packedHeight
+                            slice.trimmedWidth,
+                            slice.trimmedHeight
                         ),
-                        AtlasPage.Size(slice.originalWidth, slice.originalHeight)
+                        AtlasPage.Size(slice.actualWidth, slice.actualHeight)
                     )
             }
             pages += AtlasPage(meta, frames = frames)

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureRect.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureRect.kt
@@ -61,8 +61,8 @@ open class TextureRect : Control() {
     var stretchMode = StretchMode.KEEP
 
     /**
-     * If `true`, then the internal size calculations with use the [TextureSlice.originalWidth] &
-     * [TextureSlice.originalHeight] for its sizing instead of the trimmed width & height. This is
+     * If `true`, then the internal size calculations with use the [TextureSlice.actualWidth] &
+     * [TextureSlice.actualHeight] for its sizing instead of the trimmed width & height. This is
      * useful if a TextureSlice requires the empty margin around it.
      */
     var useOriginalSize = false
@@ -103,9 +103,9 @@ open class TextureRect : Control() {
                 sliceX -= it.virtualFrame?.x ?: 0f
                 sliceY -= it.virtualFrame?.y ?: 0f
             }
-            var sliceWidth = if (useOriginalSize) it.originalWidth.toFloat() else it.width.toFloat()
+            var sliceWidth = if (useOriginalSize) it.actualWidth.toFloat() else it.width.toFloat()
             var sliceHeight =
-                if (useOriginalSize) it.originalHeight.toFloat() else it.height.toFloat()
+                if (useOriginalSize) it.actualHeight.toFloat() else it.height.toFloat()
 
             when (stretchMode) {
                 StretchMode.SCALE -> {
@@ -233,10 +233,10 @@ open class TextureRect : Control() {
         if (!minSizeInvalid) return
 
         _internalMinWidth =
-            if (useOriginalSize) _slice?.originalWidth?.toFloat() ?: 0f
+            if (useOriginalSize) _slice?.actualWidth?.toFloat() ?: 0f
             else _slice?.width?.toFloat() ?: 0f
         _internalMinHeight =
-            if (useOriginalSize) _slice?.originalHeight?.toFloat() ?: 0f
+            if (useOriginalSize) _slice?.actualHeight?.toFloat() ?: 0f
             else _slice?.height?.toFloat() ?: 0f
 
         minSizeInvalid = false


### PR DESCRIPTION
core: rename TextureSlice originalSize to actualSize