### PR TITLE
bump versions on dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
         3. `applicationVfs` for loading files at the root of the application working directory.
 - Update internal JVM `readPixmap` to use `stbimage` instead of `ImageIO`
 - Add `Compression` interface with `CompressionGZIP` implementations for jvmAndroid & js.
+- Update `kotlin` from `2.0.0` to `2.1.0`
+- Update `kotlinx-serialization` from `1.7.0` to `1.7.3`
+- Update `kotlinx.atomicfu` from `0.24.0` to `0.26.1`
+- Update `LWJGL` from `3.3.3` to `3.3.4`
 - Internal code clean up
 - Documentation tweaks and clean up
 

--- a/core/src/commonMain/kotlin/com/littlekt/file/vfs/MimeType.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/file/vfs/MimeType.kt
@@ -40,11 +40,11 @@ class MimeType(val mime: String, val exts: List<String>) {
                 TEXT_HTML,
                 TEXT_PLAIN,
                 TEXT_CSS,
-                TEXT_JS
+                TEXT_JS,
             )
         }
 
         fun getByExtension(ext: String, default: MimeType = APPLICATION_OCTET_STREAM): MimeType =
-            MimeType_byExtensions[ext.toLowerCase()] ?: default
+            MimeType_byExtensions[ext.lowercase()] ?: default
     }
 }

--- a/core/src/commonMain/kotlin/com/littlekt/file/vfs/PathInfo.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/file/vfs/PathInfo.kt
@@ -48,7 +48,7 @@ val PathInfo.fullPathWithoutExtension: String
         val startIndex = fullPathNormalized.lastIndexOfOrNull('/')?.plus(1) ?: 0
         return fullPath.substring(
             0,
-            fullPathNormalized.indexOfOrNull('.', startIndex) ?: fullPathNormalized.length
+            fullPathNormalized.indexOfOrNull('.', startIndex) ?: fullPathNormalized.length,
         )
     }
 
@@ -95,7 +95,7 @@ val PathInfo.compoundExtension: String
 
 /** /path\to/file.1.EXT -> 1.ext */
 val PathInfo.compoundExtensionLC: String
-    get() = compoundExtension.toLowerCase()
+    get() = compoundExtension.lowercase()
 
 /** /path\to/file.1.jpg -> MimeType("image/jpeg", listOf("jpg", "jpeg")) */
 val PathInfo.mimeTypeByExtension

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 download-gradle = "5.6.0"
-kotlin = "2.0.0"
+kotlin = "2.1.0"
 kotlinxHtmlVersion = "0.11.0"
-kotlinx-atomicfu = "0.24.0"
+kotlinx-atomicfu = "0.26.1"
 kotlinx-coroutines = "1.9.0-RC"
-kotlinx-serialization = "1.7.0"
-lwjgl = "3.3.3"
+kotlinx-serialization = "1.7.3"
+lwjgl = "3.3.4"
 mp3-decoder = "1.0.1"
 
 [libraries]


### PR DESCRIPTION
- Update `kotlin` from `2.0.0` to `2.1.0`
- Update `kotlinx-serialization` from `1.7.0` to `1.7.3`
- Update `kotlinx.atomicfu` from `0.24.0` to `0.26.1`
- Update `LWJGL` from `3.3.3` to `3.3.4`