### PR TITLE
js: fix JsByteSequenceStream flipping a buffer on init

### DIFF
--- a/core/src/jsMain/kotlin/com/littlekt/file/JsByteSequenceStream.kt
+++ b/core/src/jsMain/kotlin/com/littlekt/file/JsByteSequenceStream.kt
@@ -1,16 +1,13 @@
 package com.littlekt.file
 
 /**
+ * @param buffer assumed [ByteBuffer] where the position is set to be read from until the limit.
  * @author Colton Daily
  * @date 1/12/2022
  */
 class JsByteSequenceStream(val buffer: ByteBuffer) : ByteSequenceStream {
     private var chunkPosition = 0
     private var closed = false
-
-    init {
-        buffer.flip()
-    }
 
     override fun iterator(): Iterator<Byte> {
         check(!closed) { "Stream already closed!" }
@@ -29,15 +26,11 @@ class JsByteSequenceStream(val buffer: ByteBuffer) : ByteSequenceStream {
 
     override fun readChunk(size: Int): ByteArray {
         check(!closed) { "Stream already closed!" }
-        val prevPos = buffer.position
-        buffer.position = chunkPosition
         val list = ByteArray(size)
         for (i in 0 until size) {
             if (buffer.remaining <= 0) break
             list[i] = buffer.readByte
         }
-        chunkPosition = buffer.position
-        buffer.position = prevPos
         return list
     }
 

--- a/core/src/jsMain/kotlin/com/littlekt/file/JsByteSequenceStream.kt
+++ b/core/src/jsMain/kotlin/com/littlekt/file/JsByteSequenceStream.kt
@@ -6,7 +6,6 @@ package com.littlekt.file
  * @date 1/12/2022
  */
 class JsByteSequenceStream(val buffer: ByteBuffer) : ByteSequenceStream {
-    private var chunkPosition = 0
     private var closed = false
 
     override fun iterator(): Iterator<Byte> {
@@ -73,7 +72,6 @@ class JsByteSequenceStream(val buffer: ByteBuffer) : ByteSequenceStream {
     override fun reset() {
         check(!closed) { "Stream already closed!" }
         buffer.flip()
-        chunkPosition = 0
     }
 
     override fun close() {


### PR DESCRIPTION
`JsByteSeuqnceStream` would call `buffer.flip()` in `init {}` causing things like `hasRemaining()` and `readChunk` to not read anything due to the `buffer.remaining` coming back as `0`. This sequence now assumes the buffer is in a readable state.