### PR TITLE
scene-graph: add pivot values to CanvasItem

### DIFF
--- a/examples/src/commonMain/kotlin/com/littlekt/examples/HelloSceneGraphExample.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/HelloSceneGraphExample.kt
@@ -44,15 +44,21 @@ class HelloSceneGraphExample(context: Context) : ContextListener(context) {
                     //                        onUpdate { rotation += 1.degrees }
                     //                    }
 
-                    progressBar {
-                        //  pivotX = 0.5f
-                        //  pivotY = 0.5f
+                    panelContainer {
+                        pivotX = 0.5f
+                        pivotY = 0.5f
                         minWidth = 100f
                         minHeight = 100f
                         anchorLeft = 0.5f
                         anchorBottom = 0.5f
-                        value = 50f
                         onUpdate { rotation += 1.degrees }
+                        paddedContainer {
+                            padding(20)
+                            minWidth = 100f
+                            minHeight = 100f
+
+                            button { text = "Test" }
+                        }
                     }
 
                     //                    canvasLayerContainer {

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/HelloSceneGraphExample.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/HelloSceneGraphExample.kt
@@ -3,11 +3,18 @@ package com.littlekt.examples
 import com.littlekt.Context
 import com.littlekt.ContextListener
 import com.littlekt.file.vfs.readTexture
+import com.littlekt.graph.node.canvasLayer
+import com.littlekt.graph.node.node2d.camera2d
+import com.littlekt.graph.node.node2d.node2d
 import com.littlekt.graph.node.ui.*
 import com.littlekt.graph.sceneGraph
 import com.littlekt.graphics.Color
+import com.littlekt.graphics.HAlign
+import com.littlekt.graphics.VAlign
 import com.littlekt.graphics.webgpu.*
+import com.littlekt.input.Key
 import com.littlekt.math.geom.degrees
+import com.littlekt.math.geom.radians
 import com.littlekt.util.viewport.ExtendViewport
 
 /**
@@ -36,113 +43,96 @@ class HelloSceneGraphExample(context: Context) : ContextListener(context) {
 
         val graph =
             sceneGraph(this, ExtendViewport(960, 540)) {
-                    //                    panelContainer {
-                    //                        pivotX = 0.5f
-                    //                        pivotY = 0.5f
-                    //                        width = 150f
-                    //                        height = 100f
-                    //                        onUpdate { rotation += 1.degrees }
-                    //                    }
+                    canvasLayerContainer {
+                        stretch = true
+                        shrink = 2
+                        anchorRight = 1f
+                        anchorTop = 1f
 
-                    panelContainer {
-                        pivotX = 0.5f
-                        pivotY = 0.5f
-                        minWidth = 100f
-                        minHeight = 100f
-                        anchorLeft = 0.5f
-                        anchorBottom = 0.5f
-                        onUpdate { rotation += 1.degrees }
-                        paddedContainer {
-                            padding(20)
-                            minWidth = 100f
-                            minHeight = 100f
+                        canvasLayer {
+                            scrollContainer {
+                                minWidth = 100f
+                                minHeight = 100f
+                                column {
+                                    repeat(10) {
+                                        label { text = "hi: this is rreallylognadsfda ad$it" }
+                                    }
+                                }
+                            }
+                            node2d {
+                                rotation = 45.degrees
+                                onReady += { println("$name: $canvas") }
+                                onUpdate += {
+                                    if (input.isKeyPressed(Key.D)) {
+                                        globalX += 1f
+                                    } else if (input.isKeyPressed(Key.A)) {
+                                        globalX -= 1f
+                                    }
 
-                            button { text = "Test" }
+                                    if (input.isKeyPressed(Key.S)) {
+                                        globalY -= 1f
+                                    } else if (input.isKeyPressed(Key.W)) {
+                                        globalY += 1f
+                                    }
+                                }
+                                onRender += { batch, _, _ ->
+                                    val originX = icon.width * pivotX
+                                    val originY = icon.height * pivotY
+                                    batch.draw(
+                                        texture = icon,
+                                        x = globalX - originX,
+                                        y = globalY - originY,
+                                        originX = originX,
+                                        originY = originY,
+                                        rotation = globalRotation,
+                                    )
+                                }
+                                camera2d { active = true }
+                            }
+
+                            node2d {
+                                x = 100f
+                                y = 20f
+                                onRender += { batch, _, _ ->
+                                    rotation += 0.01.radians
+                                    val originX = icon.width * pivotX
+                                    val originY = icon.height * pivotY
+                                    batch.draw(
+                                        texture = icon,
+                                        x = globalX - originX,
+                                        y = globalY - originY,
+                                        originX = originX,
+                                        originY = originY,
+                                        scaleX = 2f,
+                                        scaleY = 2f,
+                                        rotation = globalRotation,
+                                    )
+                                }
+                            }
                         }
                     }
+                    centerContainer {
+                        anchorRight = 1f
+                        anchorTop = 1f
+                        button {
+                            x = 200f
+                            y = 300f
+                            text = "center button"
+                            horizontalAlign = HAlign.CENTER
+                            verticalAlign = VAlign.CENTER
 
-                    //                    canvasLayerContainer {
-                    //                        stretch = true
-                    //                        shrink = 2
-                    //                        anchorRight = 1f
-                    //                        anchorTop = 1f
-                    //
-                    //                        canvasLayer {
-                    //                            scrollContainer {
-                    //                                minWidth = 100f
-                    //                                minHeight = 100f
-                    //                                column {
-                    //                                    repeat(10) {
-                    //                                        label { text = "hi: this is rreally
-                    // lognadsfda ad$it" }
-                    //                                    }
-                    //                                }
-                    //                            }
-                    //                            node2d {
-                    //                                rotation = 45.degrees
-                    //                                onReady += { println("$name: $canvas") }
-                    //                                onUpdate += {
-                    //                                    if (input.isKeyPressed(Key.D)) {
-                    //                                        globalX += 1f
-                    //                                    } else if (input.isKeyPressed(Key.A)) {
-                    //                                        globalX -= 1f
-                    //                                    }
-                    //
-                    //                                    if (input.isKeyPressed(Key.S)) {
-                    //                                        globalY -= 1f
-                    //                                    } else if (input.isKeyPressed(Key.W)) {
-                    //                                        globalY += 1f
-                    //                                    }
-                    //                                }
-                    //                                onRender += { batch, camera, shapeRenderer ->
-                    //                                    batch.draw(icon, globalX, globalY,
-                    // rotation = globalRotation)
-                    //                                }
-                    //                                camera2d { active = true }
-                    //                            }
-                    //
-                    //                            var rotation = Angle.ZERO
-                    //                            node2d {
-                    //                                x = 100f
-                    //                                y = 20f
-                    //                                onRender += { batch, camera, shapeRenderer ->
-                    //                                    rotation += 0.01.radians
-                    //                                    batch.draw(
-                    //                                        icon,
-                    //                                        globalX,
-                    //                                        globalY,
-                    //                                        scaleX = 2f,
-                    //                                        scaleY = 2f,
-                    //                                        rotation = rotation
-                    //                                    )
-                    //                                }
-                    //                            }
-                    //                        }
-                    //                    }
-                    //                    centerContainer {
-                    //                        anchorRight = 1f
-                    //                        anchorTop = 1f
-                    //                        button {
-                    //                            x = 200f
-                    //                            y = 300f
-                    //                            text = "center button"
-                    //                            horizontalAlign = HAlign.CENTER
-                    //                            verticalAlign = VAlign.CENTER
-                    //
-                    //                            onReady += {
-                    // println("$name:${canvas!!::class.simpleName} - $canvas") }
-                    //                        }
-                    //                    }
-                    //                    button {
-                    //                        x = 200f
-                    //                        y = 300f
-                    //                        text = "outsied button"
-                    //                        horizontalAlign = HAlign.CENTER
-                    //                        verticalAlign = VAlign.CENTER
-                    //
-                    //                        onReady += {
-                    // println("$name:${canvas!!::class.simpleName} - $canvas") }
-                    //                    }
+                            onReady += { println("$name:${canvas!!::class.simpleName} - $canvas") }
+                        }
+                    }
+                    button {
+                        x = 200f
+                        y = 300f
+                        text = "outsied button"
+                        horizontalAlign = HAlign.CENTER
+                        verticalAlign = VAlign.CENTER
+
+                        onReady += { println("$name:${canvas!!::class.simpleName} - $canvas") }
+                    }
                 }
                 .also { it.initialize() }
 

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/HelloSceneGraphExample.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/HelloSceneGraphExample.kt
@@ -3,19 +3,11 @@ package com.littlekt.examples
 import com.littlekt.Context
 import com.littlekt.ContextListener
 import com.littlekt.file.vfs.readTexture
-import com.littlekt.graph.node.canvasLayer
-import com.littlekt.graph.node.node2d.camera2d
-import com.littlekt.graph.node.node2d.node2d
 import com.littlekt.graph.node.ui.*
 import com.littlekt.graph.sceneGraph
 import com.littlekt.graphics.Color
-import com.littlekt.graphics.HAlign
-import com.littlekt.graphics.VAlign
 import com.littlekt.graphics.webgpu.*
-import com.littlekt.input.Key
-import com.littlekt.math.geom.Angle
 import com.littlekt.math.geom.degrees
-import com.littlekt.math.geom.radians
 import com.littlekt.util.viewport.ExtendViewport
 
 /**
@@ -39,89 +31,112 @@ class HelloSceneGraphExample(context: Context) : ContextListener(context) {
             TextureUsage.RENDER_ATTACHMENT,
             preferredFormat,
             PresentMode.FIFO,
-            surfaceCapabilities.alphaModes[0]
+            surfaceCapabilities.alphaModes[0],
         )
 
         val graph =
             sceneGraph(this, ExtendViewport(960, 540)) {
-                    canvasLayerContainer {
-                        stretch = true
-                        shrink = 2
-                        anchorRight = 1f
-                        anchorTop = 1f
+                    //                    panelContainer {
+                    //                        pivotX = 0.5f
+                    //                        pivotY = 0.5f
+                    //                        width = 150f
+                    //                        height = 100f
+                    //                        onUpdate { rotation += 1.degrees }
+                    //                    }
 
-                        canvasLayer {
-                            scrollContainer {
-                                minWidth = 100f
-                                minHeight = 100f
-                                column {
-                                    repeat(10) {
-                                        label { text = "hi: this is rreally lognadsfda ad$it" }
-                                    }
-                                }
-                            }
-                            node2d {
-                                rotation = 45.degrees
-                                onReady += { println("$name: $canvas") }
-                                onUpdate += {
-                                    if (input.isKeyPressed(Key.D)) {
-                                        globalX += 1f
-                                    } else if (input.isKeyPressed(Key.A)) {
-                                        globalX -= 1f
-                                    }
-
-                                    if (input.isKeyPressed(Key.S)) {
-                                        globalY -= 1f
-                                    } else if (input.isKeyPressed(Key.W)) {
-                                        globalY += 1f
-                                    }
-                                }
-                                onRender += { batch, camera, shapeRenderer ->
-                                    batch.draw(icon, globalX, globalY, rotation = globalRotation)
-                                }
-                                camera2d { active = true }
-                            }
-
-                            var rotation = Angle.ZERO
-                            node2d {
-                                x = 100f
-                                y = 20f
-                                onRender += { batch, camera, shapeRenderer ->
-                                    rotation += 0.01.radians
-                                    batch.draw(
-                                        icon,
-                                        globalX,
-                                        globalY,
-                                        scaleX = 2f,
-                                        scaleY = 2f,
-                                        rotation = rotation
-                                    )
-                                }
-                            }
-                        }
+                    progressBar {
+                        //  pivotX = 0.5f
+                        //  pivotY = 0.5f
+                        minWidth = 100f
+                        minHeight = 100f
+                        anchorLeft = 0.5f
+                        anchorBottom = 0.5f
+                        value = 50f
+                        onUpdate { rotation += 1.degrees }
                     }
-                    centerContainer {
-                        anchorRight = 1f
-                        anchorTop = 1f
-                        button {
-                            x = 200f
-                            y = 300f
-                            text = "center button"
-                            horizontalAlign = HAlign.CENTER
-                            verticalAlign = VAlign.CENTER
 
-                            onReady += { println("$name:${canvas!!::class.simpleName} - $canvas") }
-                        }
-                    }
-                    button {
-                        x = 200f
-                        y = 300f
-                        text = "outsied button"
-                        horizontalAlign = HAlign.CENTER
-                        verticalAlign = VAlign.CENTER
-
-                        onReady += { println("$name:${canvas!!::class.simpleName} - $canvas") }
-                    }
+                    //                    canvasLayerContainer {
+                    //                        stretch = true
+                    //                        shrink = 2
+                    //                        anchorRight = 1f
+                    //                        anchorTop = 1f
+                    //
+                    //                        canvasLayer {
+                    //                            scrollContainer {
+                    //                                minWidth = 100f
+                    //                                minHeight = 100f
+                    //                                column {
+                    //                                    repeat(10) {
+                    //                                        label { text = "hi: this is rreally
+                    // lognadsfda ad$it" }
+                    //                                    }
+                    //                                }
+                    //                            }
+                    //                            node2d {
+                    //                                rotation = 45.degrees
+                    //                                onReady += { println("$name: $canvas") }
+                    //                                onUpdate += {
+                    //                                    if (input.isKeyPressed(Key.D)) {
+                    //                                        globalX += 1f
+                    //                                    } else if (input.isKeyPressed(Key.A)) {
+                    //                                        globalX -= 1f
+                    //                                    }
+                    //
+                    //                                    if (input.isKeyPressed(Key.S)) {
+                    //                                        globalY -= 1f
+                    //                                    } else if (input.isKeyPressed(Key.W)) {
+                    //                                        globalY += 1f
+                    //                                    }
+                    //                                }
+                    //                                onRender += { batch, camera, shapeRenderer ->
+                    //                                    batch.draw(icon, globalX, globalY,
+                    // rotation = globalRotation)
+                    //                                }
+                    //                                camera2d { active = true }
+                    //                            }
+                    //
+                    //                            var rotation = Angle.ZERO
+                    //                            node2d {
+                    //                                x = 100f
+                    //                                y = 20f
+                    //                                onRender += { batch, camera, shapeRenderer ->
+                    //                                    rotation += 0.01.radians
+                    //                                    batch.draw(
+                    //                                        icon,
+                    //                                        globalX,
+                    //                                        globalY,
+                    //                                        scaleX = 2f,
+                    //                                        scaleY = 2f,
+                    //                                        rotation = rotation
+                    //                                    )
+                    //                                }
+                    //                            }
+                    //                        }
+                    //                    }
+                    //                    centerContainer {
+                    //                        anchorRight = 1f
+                    //                        anchorTop = 1f
+                    //                        button {
+                    //                            x = 200f
+                    //                            y = 300f
+                    //                            text = "center button"
+                    //                            horizontalAlign = HAlign.CENTER
+                    //                            verticalAlign = VAlign.CENTER
+                    //
+                    //                            onReady += {
+                    // println("$name:${canvas!!::class.simpleName} - $canvas") }
+                    //                        }
+                    //                    }
+                    //                    button {
+                    //                        x = 200f
+                    //                        y = 300f
+                    //                        text = "outsied button"
+                    //                        horizontalAlign = HAlign.CENTER
+                    //                        verticalAlign = VAlign.CENTER
+                    //
+                    //                        onReady += {
+                    // println("$name:${canvas!!::class.simpleName} - $canvas") }
+                    //                    }
                 }
                 .also { it.initialize() }
 
@@ -132,7 +147,7 @@ class HelloSceneGraphExample(context: Context) : ContextListener(context) {
                 TextureUsage.RENDER_ATTACHMENT,
                 preferredFormat,
                 PresentMode.FIFO,
-                surfaceCapabilities.alphaModes[0]
+                surfaceCapabilities.alphaModes[0],
             )
         }
 
@@ -169,10 +184,10 @@ class HelloSceneGraphExample(context: Context) : ContextListener(context) {
                             storeOp = StoreOp.STORE,
                             clearColor =
                                 if (preferredFormat.srgb) Color.DARK_GRAY.toLinear()
-                                else Color.DARK_GRAY
+                                else Color.DARK_GRAY,
                         )
                     ),
-                    label = "Init render pass"
+                    label = "Init render pass",
                 )
             graph.update(dt)
             graph.render(commandEncoder, renderPassDescriptor)

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/CanvasItem.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/CanvasItem.kt
@@ -3,7 +3,10 @@ package com.littlekt.graph.node
 import com.littlekt.graph.SceneGraph
 import com.littlekt.graph.node.render.Material
 import com.littlekt.graph.node.resource.InputEvent
-import com.littlekt.graph.util.*
+import com.littlekt.graph.util.Signal
+import com.littlekt.graph.util.TripleSignal
+import com.littlekt.graph.util.signal
+import com.littlekt.graph.util.signal3v
 import com.littlekt.graphics.Camera
 import com.littlekt.graphics.g2d.Batch
 import com.littlekt.graphics.g2d.shape.ShapeRenderer
@@ -24,6 +27,7 @@ abstract class CanvasItem : Node() {
         const val SCALE_DIRTY = 2
         const val ROTATION_DIRTY = 3
         const val CLEAN = 0
+        const val PIVOT_DIRTY = 5
 
         private val tempVec = MutableVec2f()
     }
@@ -370,6 +374,28 @@ abstract class CanvasItem : Node() {
                 _globalToLocalDirty = false
             }
             return _globalToLocalTransform
+        }
+
+    /** A point between 0f to 1f. */
+    var pivotX: Float = 0f
+        set(value) {
+            if (value == field) return
+            require(value in 0f..1f) { "Value must be between 0f and 1f!" }
+            field = value
+            if (insideTree) {
+                dirty(PIVOT_DIRTY)
+            }
+        }
+
+    /** A point between 0f to 1f. */
+    var pivotY: Float = 0f
+        set(value) {
+            if (value == field) return
+            require(value in 0f..1f) { "Value must be between 0f and 1f!" }
+            field = value
+            if (insideTree) {
+                dirty(PIVOT_DIRTY)
+            }
         }
 
     override val membersAndPropertiesString: String

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/Drawable.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/Drawable.kt
@@ -36,11 +36,13 @@ interface Drawable {
         batch: Batch,
         x: Float,
         y: Float,
+        originX: Float,
+        originY: Float,
         width: Float,
         height: Float,
         scaleX: Float = 1f,
         scaleY: Float = 1f,
         rotation: Angle = Angle.ZERO,
-        color: Color = tint
+        color: Color = tint,
     )
 }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/EmptyDrawable.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/EmptyDrawable.kt
@@ -59,6 +59,8 @@ object EmptyDrawable : Drawable {
         batch: Batch,
         x: Float,
         y: Float,
+        originX: Float,
+        originY: Float,
         width: Float,
         height: Float,
         scaleX: Float,

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/NinePatchDrawable.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/NinePatchDrawable.kt
@@ -27,13 +27,27 @@ class NinePatchDrawable(val ninePatch: NinePatch) : Drawable {
         batch: Batch,
         x: Float,
         y: Float,
+        originX: Float,
+        originY: Float,
         width: Float,
         height: Float,
         scaleX: Float,
         scaleY: Float,
         rotation: Angle,
-        color: Color
+        color: Color,
     ) {
-        ninePatch.draw(batch, x, y, width, height, 0f, 0f, scaleX, scaleY, rotation, color)
+        ninePatch.draw(
+            batch = batch,
+            x = x,
+            y = y,
+            originX = originX,
+            originY = originY,
+            width = width,
+            height = height,
+            scaleX = scaleX,
+            scaleY = scaleY,
+            rotation = rotation,
+            color = color,
+        )
     }
 }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/TextureSliceDrawable.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/resource/TextureSliceDrawable.kt
@@ -1,8 +1,10 @@
 package com.littlekt.graph.node.resource
 
-import com.littlekt.graphics.*
+import com.littlekt.graphics.Color
+import com.littlekt.graphics.Texture
 import com.littlekt.graphics.g2d.Batch
 import com.littlekt.graphics.g2d.TextureSlice
+import com.littlekt.graphics.slice
 import com.littlekt.math.geom.Angle
 
 /**
@@ -29,23 +31,27 @@ class TextureSliceDrawable(val slice: TextureSlice) : Drawable {
         batch: Batch,
         x: Float,
         y: Float,
+        originX: Float,
+        originY: Float,
         width: Float,
         height: Float,
         scaleX: Float,
         scaleY: Float,
         rotation: Angle,
-        color: Color
+        color: Color,
     ) {
         batch.draw(
-            slice,
-            x,
-            y,
+            slice = slice,
+            x = x,
+            y = y,
+            originX = originX,
+            originY = originY,
             width = width,
             height = height,
             scaleX = scaleX,
             scaleY = scaleY,
             rotation = rotation,
-            color = color
+            color = color,
         )
     }
 }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/BoxContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/BoxContainer.kt
@@ -97,7 +97,7 @@ abstract class BoxContainer : Container() {
                         MinSizeCache(
                             minSize = minSize,
                             willStretch = willStretch,
-                            finalSize = minSize
+                            finalSize = minSize,
                         )
                 }
                 childrenCount++
@@ -229,7 +229,7 @@ abstract class BoxContainer : Container() {
                         tHeight = height
                     }
 
-                    fitChild(child, tx, ty, tWidth, tHeight)
+                    fitChild(child, tx - originX, ty - originY, tWidth, tHeight)
                     ofs = to
                     idx++
                 }
@@ -240,6 +240,6 @@ abstract class BoxContainer : Container() {
     private data class MinSizeCache(
         var minSize: Int = 0,
         var willStretch: Boolean = false,
-        var finalSize: Int = 0
+        var finalSize: Int = 0,
     )
 }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Button.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Button.kt
@@ -202,29 +202,33 @@ open class Button : BaseButton() {
         }
 
         drawable.draw(
-            batch,
-            globalX,
-            globalY,
+            batch = batch,
+            x = globalX - originX,
+            y = globalY - originY,
+            originX = originX,
+            originY = originY,
             width = width,
             height = height,
             scaleX = globalScaleX,
             scaleY = globalScaleY,
-            rotation = rotation,
-            color = drawable.tint
+            rotation = globalRotation,
+            color = drawable.tint,
         )
 
         if (hasFocus) {
             val focusDrawable = getThemeDrawable(themeVars.focus)
             focusDrawable.draw(
-                batch,
-                globalX,
-                globalY,
+                batch = batch,
+                x = globalX - originX,
+                y = globalY - originY,
+                originX = originX,
+                originY = originY,
                 width = width,
                 height = height,
                 scaleX = globalScaleX,
                 scaleY = globalScaleY,
-                rotation = rotation,
-                color = focusDrawable.tint
+                rotation = globalRotation,
+                color = focusDrawable.tint,
             )
         }
         cache.let {
@@ -271,7 +275,7 @@ open class Button : BaseButton() {
             scaleY = fontScaleY,
             horizontalAlign,
             wrap,
-            ellipsis
+            ellipsis,
         )
         val textWidth: Float = max(layout.width, width)
         val textHeight: Float = if (wrap || text.contains("\n")) layout.height else font.capHeight
@@ -303,6 +307,8 @@ open class Button : BaseButton() {
             }
         }
         ty = ty.roundToInt().toFloat()
+        tx -= originX
+        ty -= originY
 
         layout.setText(
             font,
@@ -313,7 +319,7 @@ open class Button : BaseButton() {
             scaleY = fontScaleY,
             horizontalAlign,
             wrap,
-            ellipsis
+            ellipsis,
         )
         cache.setText(layout, tx, ty, fontScaleX, fontScaleY)
     }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/CanvasLayerContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/CanvasLayerContainer.kt
@@ -123,9 +123,11 @@ open class CanvasLayerContainer : Container() {
         fbos.forEach { fbo ->
             val target = fbo.target
             batch.draw(
-                target,
-                globalX - margin / shrink + offsetX,
-                globalY - margin / shrink + offsetY,
+                texture = target,
+                x = globalX - margin / shrink + offsetX - originX,
+                y = globalY - margin / shrink + offsetY - originY,
+                originX = originX,
+                originY = originY,
                 width =
                     if (stretch) width + margin * 2 / shrink
                     else target.width.toFloat() + margin * 2 / shrink,

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/CanvasLayerContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/CanvasLayerContainer.kt
@@ -115,7 +115,7 @@ open class CanvasLayerContainer : Container() {
             fbos.forEach {
                 it.resizeFbo(
                     (width / shrink.toFloat()).toInt(),
-                    (height / shrink.toFloat()).toInt()
+                    (height / shrink.toFloat()).toInt(),
                 )
             }
             dirty = false
@@ -134,7 +134,7 @@ open class CanvasLayerContainer : Container() {
                     else target.height.toFloat() + margin * 2 / shrink,
                 scaleX = globalScaleX,
                 scaleY = globalScaleY,
-                rotation = globalRotation
+                rotation = globalRotation,
             )
         }
     }
@@ -178,7 +178,7 @@ open class CanvasLayerContainer : Container() {
                 if (it is CanvasLayer) {
                     temp.scale(
                         1f / (width / it.virtualWidth) * shrink,
-                        1f / (height / it.virtualHeight) * shrink
+                        1f / (height / it.virtualHeight) * shrink,
                     )
                     it.propagateHit(temp.x, temp.y)
                 } else {
@@ -207,7 +207,7 @@ open class CanvasLayerContainer : Container() {
             if (it is CanvasLayer) {
                 temp.scale(
                     1f / (width / it.virtualWidth) * shrink,
-                    1f / (height / it.virtualHeight) * shrink
+                    1f / (height / it.virtualHeight) * shrink,
                 )
                 event.canvasX = temp.x
                 event.canvasY = temp.y
@@ -239,7 +239,7 @@ open class CanvasLayerContainer : Container() {
             if (it is CanvasLayer) {
                 temp.scale(
                     1f / (width / it.virtualWidth) * shrink,
-                    1f / (height / it.virtualHeight) * shrink
+                    1f / (height / it.virtualHeight) * shrink,
                 )
                 event.canvasX = temp.x
                 event.canvasY = temp.y

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/CenterContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/CenterContainer.kt
@@ -50,8 +50,8 @@ open class CenterContainer : Container() {
     override fun onSortChildren() {
         nodes.forEach {
             if (it is Control && it.enabled && !it.isDestroyed) {
-                val newX = floor((width - it.combinedMinWidth) * 0.5f)
-                val newY = floor((height - it.combinedMinHeight) * 0.5f)
+                val newX = floor((width - it.combinedMinWidth) * 0.5f) - originX
+                val newY = floor((height - it.combinedMinHeight) * 0.5f) - originY
                 fitChild(it, newX, newY, it.combinedMinWidth, it.combinedMinHeight)
             }
         }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Label.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Label.kt
@@ -211,7 +211,7 @@ open class Label : Control() {
                 scaleY = fontScaleY,
                 align = horizontalAlign,
                 wrap = wrap,
-                truncate = ellipsis
+                truncate = ellipsis,
             )
             textWidth = layout.width
             textHeight = layout.height
@@ -255,9 +255,9 @@ open class Label : Control() {
             scaleY = fontScaleY,
             horizontalAlign,
             wrap,
-            ellipsis
+            ellipsis,
         )
-        cache.setText(layout, tx, ty, fontScaleX, fontScaleY)
+        cache.setText(layout, tx - originX, ty - originY, fontScaleX, fontScaleY)
         _internalMinWidth = layout.width
         _internalMinHeight = layout.height
     }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/NinePatchRect.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/NinePatchRect.kt
@@ -101,15 +101,17 @@ open class NinePatchRect : Control() {
 
     override fun render(batch: Batch, camera: Camera, shapeRenderer: ShapeRenderer) {
         ninePatch.draw(
-            batch,
-            globalX,
-            globalY,
-            width,
-            height,
+            batch = batch,
+            x = globalX - originX,
+            y = globalY - originY,
+            originX = originX,
+            originY = originY,
+            width = width,
+            height = height,
             color = color,
             scaleX = globalScaleX,
             scaleY = globalScaleY,
-            rotation = globalRotation
+            rotation = globalRotation,
         )
     }
 }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PaddedContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PaddedContainer.kt
@@ -122,7 +122,13 @@ open class PaddedContainer : Container() {
             if (it is Control && it.enabled && it.visible && !it.isDestroyed) {
                 val w = width - paddingLeft - paddingRight
                 val h = height - paddingTop - paddingBottom
-                fitChild(it, paddingLeft.toFloat(), paddingBottom.toFloat(), w, h)
+                fitChild(
+                    it,
+                    paddingLeft.toFloat() - originX,
+                    paddingBottom.toFloat() - originY,
+                    w,
+                    h,
+                )
                 it.computeMargins()
             }
         }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Panel.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/Panel.kt
@@ -59,13 +59,25 @@ open class Panel : Control() {
 
     override fun render(batch: Batch, camera: Camera, shapeRenderer: ShapeRenderer) {
         panel.let {
-            it.draw(batch, globalX, globalY, width, height, scaleX, scaleY, rotation, it.tint)
+            it.draw(
+                batch = batch,
+                x = globalX - originX,
+                y = globalY - originY,
+                originX = originX,
+                originY = originY,
+                width = width,
+                height = height,
+                scaleX = globalScaleX,
+                scaleY = globalScaleY,
+                rotation = globalRotation,
+                color = it.tint,
+            )
         }
     }
 
     enum class Mode {
         BACKGROUND,
-        FOREGROUND
+        FOREGROUND,
     }
 
     class ThemeVars {

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PanelContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PanelContainer.kt
@@ -111,7 +111,7 @@ open class PanelContainer : Container() {
 
         nodes.forEach {
             if (it is Control && it.enabled && !it.isDestroyed) {
-                fitChild(it, panel.marginLeft, panel.marginBottom, w, h)
+                fitChild(it, panel.marginLeft - originX, panel.marginBottom - originY, w, h)
             }
         }
     }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PanelContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/PanelContainer.kt
@@ -61,7 +61,19 @@ open class PanelContainer : Container() {
 
     override fun render(batch: Batch, camera: Camera, shapeRenderer: ShapeRenderer) {
         panel.let {
-            it.draw(batch, globalX, globalY, width, height, scaleX, scaleY, rotation, it.tint)
+            it.draw(
+                batch = batch,
+                x = globalX - originX,
+                y = globalY - originY,
+                originX = originX,
+                originY = originY,
+                width = width,
+                height = height,
+                scaleX = scaleX,
+                scaleY = scaleY,
+                rotation = rotation,
+                color = it.tint,
+            )
         }
     }
 

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ProgressBar.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ProgressBar.kt
@@ -86,10 +86,32 @@ open class ProgressBar : Range() {
     private val layout = GlyphLayout()
 
     override fun render(batch: Batch, camera: Camera, shapeRenderer: ShapeRenderer) {
-        bg.draw(batch, globalX, globalY, width, height)
+        bg.draw(
+            batch = batch,
+            x = globalX - originX,
+            y = globalY - originY,
+            originX = originX,
+            originY = originY,
+            width = width,
+            height = height,
+            scaleX = globalScaleX,
+            scaleY = globalScaleY,
+            rotation = globalRotation,
+        )
         val progress = ratio * (width - fg.minWidth)
         if (progress > 0) {
-            fg.draw(batch, globalX, globalY, progress + fg.minWidth, height)
+            fg.draw(
+                batch = batch,
+                x = globalX - originX,
+                y = globalY - originY,
+                originX = originX,
+                originY = originY,
+                width = progress + fg.minWidth,
+                height = height,
+                scaleX = globalScaleX,
+                scaleY = globalScaleY,
+                rotation = globalRotation,
+            )
         }
 
         if (percentVisible) {

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ScrollBar.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ScrollBar.kt
@@ -257,14 +257,16 @@ abstract class ScrollBar(val orientation: Orientation = Orientation.VERTICAL) : 
             }
 
         decrement.draw(
-            batch,
-            globalPosition.x,
-            globalPosition.y,
-            decrement.minWidth,
-            decrement.minHeight,
-            globalScaleX,
-            globalScaleY,
-            globalRotation
+            batch = batch,
+            x = globalX - originX,
+            y = globalY - originY,
+            originX = originX,
+            originY = originY,
+            width = decrement.minWidth,
+            height = decrement.minHeight,
+            scaleX = globalScaleX,
+            scaleY = globalScaleY,
+            rotation = globalRotation,
         )
 
         var offsetX = globalPosition.x
@@ -284,14 +286,16 @@ abstract class ScrollBar(val orientation: Orientation = Orientation.VERTICAL) : 
         }
 
         bg.draw(
-            batch,
-            offsetX,
-            offsetY,
-            areaWidth,
-            areaHeight,
-            globalScaleX,
-            globalScaleY,
-            globalRotation
+            batch = batch,
+            x = offsetX - originX,
+            y = offsetY - originY,
+            originX = originX,
+            originY = originY,
+            width = areaWidth,
+            height = areaHeight,
+            scaleX = globalScaleX,
+            scaleY = globalScaleY,
+            rotation = globalRotation,
         )
 
         if (orientation == Orientation.HORIZONTAL) {
@@ -301,14 +305,16 @@ abstract class ScrollBar(val orientation: Orientation = Orientation.VERTICAL) : 
         }
 
         increment.draw(
-            batch,
-            offsetX,
-            offsetY,
-            increment.minWidth,
-            increment.minHeight,
-            globalScaleX,
-            globalScaleY,
-            globalRotation
+            batch = batch,
+            x = offsetX - originX,
+            y = offsetY - originY,
+            originX = originX,
+            originY = originY,
+            width = increment.minWidth,
+            height = increment.minHeight,
+            scaleX = globalScaleX,
+            scaleY = globalScaleY,
+            rotation = globalRotation,
         )
 
         val grabberWidth: Float
@@ -326,14 +332,16 @@ abstract class ScrollBar(val orientation: Orientation = Orientation.VERTICAL) : 
         }
 
         grabber.draw(
-            batch,
-            grabberX,
-            grabberY,
-            grabberWidth,
-            grabberHeight,
-            globalScaleX,
-            globalScaleY,
-            globalRotation
+            batch = batch,
+            x = grabberX - originX,
+            y = grabberY - originY,
+            originX = originX,
+            originY = originY,
+            width = grabberWidth,
+            height = grabberHeight,
+            scaleX = globalScaleX,
+            scaleY = globalScaleY,
+            rotation = globalRotation,
         )
     }
 
@@ -401,7 +409,7 @@ abstract class ScrollBar(val orientation: Orientation = Orientation.VERTICAL) : 
         NONE,
         DECREMENT,
         RANGE,
-        INCREMENT
+        INCREMENT,
     }
 
     class ThemeVars {

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ScrollContainer.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/ScrollContainer.kt
@@ -314,22 +314,24 @@ class ScrollContainer : Container(), GestureProcessor {
         val canvas = canvas ?: return
 
         panel.draw(
-            batch,
-            globalX,
-            globalY,
-            width,
-            height,
-            globalScaleX,
-            globalScaleY,
-            globalRotation
+            batch = batch,
+            x = globalX - originX,
+            y = globalY - originY,
+            originX = originX,
+            originY = originY,
+            width = width,
+            height = height,
+            scaleX = globalScaleX,
+            scaleY = globalScaleY,
+            rotation = globalRotation,
         )
 
-        tempVec2.set(globalX, globalY)
+        tempVec2.set(globalX - originX, globalY - originY)
         tempVec2.mul(batch.transformMatrix)
         canvas.canvasToScreenCoordinates(tempVec2)
         val scissorX = tempVec2.x
         val scissorY = tempVec2.y
-        tempVec2.set(globalX + width, globalY + height)
+        tempVec2.set(globalX + width - originX, globalY + height - originY)
         tempVec2.mul(batch.transformMatrix)
         canvas.canvasToScreenCoordinates(tempVec2)
         val scissorWidth = tempVec2.x - scissorX
@@ -339,7 +341,7 @@ class ScrollContainer : Container(), GestureProcessor {
             scissorX.toInt(),
             scissorY.toInt(),
             scissorWidth.toInt(),
-            scissorHeight.toInt()
+            scissorHeight.toInt(),
         )
     }
 
@@ -414,7 +416,7 @@ class ScrollContainer : Container(), GestureProcessor {
             ty += panel.marginBottom - th
             tx = tx.floor()
             ty = ty.floor()
-            fitChild(it, tx, ty, tw, th)
+            fitChild(it, tx - originX, ty - originY, tw, th)
         }
     }
 
@@ -424,22 +426,22 @@ class ScrollContainer : Container(), GestureProcessor {
 
     private fun updateScrollbarPosition() {
         hScrollBar.anchorLeft = 0f
-        hScrollBar.marginLeft = 0f
+        hScrollBar.marginLeft = -originX
         hScrollBar.anchorRight = 1f
-        hScrollBar.marginRight = 0f
+        hScrollBar.marginRight = -originX
         hScrollBar.anchorBottom = 0f
-        hScrollBar.marginBottom = 0f
+        hScrollBar.marginBottom = -originY
         hScrollBar.anchorTop = 0f
-        hScrollBar.marginTop = 0f
+        hScrollBar.marginTop = -originY
 
         vScrollBar.anchorLeft = 1f
-        vScrollBar.marginLeft = -vScrollBar.width
+        vScrollBar.marginLeft = -vScrollBar.width - originX
         vScrollBar.anchorRight = 1f
-        vScrollBar.marginRight = 0f
+        vScrollBar.marginRight = -originX
         vScrollBar.anchorBottom = 0f
-        vScrollBar.marginBottom = 0f
+        vScrollBar.marginBottom = -originY
         vScrollBar.anchorTop = 1f
-        vScrollBar.marginTop = 0f
+        vScrollBar.marginTop = -originY
     }
 
     /** The type of scrolling. */
@@ -457,7 +459,7 @@ class ScrollContainer : Container(), GestureProcessor {
         ALWAYS,
 
         /** Scroll is disabled and the scrollbar is hidden. */
-        NEVER
+        NEVER,
     }
 
     class ThemeVars {

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureProgress.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureProgress.kt
@@ -185,11 +185,13 @@ open class TextureProgress : Range() {
 
         if (useNinePatch) {
             backgroundNine?.draw(
-                batch,
-                globalX,
-                globalY,
-                width,
-                height,
+                batch = batch,
+                x = globalX - originX,
+                y = globalY - originY,
+                originX = originX,
+                originY = originY,
+                width = width,
+                height = height,
                 scaleX = globalScaleX,
                 scaleY = globalScaleY,
                 rotation = globalRotation,
@@ -200,25 +202,29 @@ open class TextureProgress : Range() {
                 when (fillMode) {
                     FillMode.LEFT_TO_RIGHT -> {
                         progressNine?.draw(
-                            batch,
-                            globalX,
-                            globalY,
-                            width,
-                            height,
+                            batch = batch,
+                            x = globalX - originX,
+                            y = globalY - originY,
+                            originX = originX,
+                            originY = originY,
+                            width = width,
+                            height = height,
                             scaleX = globalScaleX,
                             scaleY = globalScaleY,
                             rotation = globalRotation,
                             color = progressBarColor,
-                            srcWidth = width - width * (1f - ratio)
+                            srcWidth = width - width * (1f - ratio),
                         )
                     }
                     FillMode.RIGHT_TO_LEFT -> {
                         progressNine?.draw(
-                            batch,
-                            globalX,
-                            globalY,
-                            width,
-                            height,
+                            batch = batch,
+                            x = globalX - originX,
+                            y = globalY - originY,
+                            originX = originX,
+                            originY = originY,
+                            width = width,
+                            height = height,
                             scaleX = globalScaleX,
                             scaleY = globalScaleY,
                             rotation = globalRotation,
@@ -228,25 +234,29 @@ open class TextureProgress : Range() {
                     }
                     FillMode.TOP_TO_BOTTOM -> {
                         progressNine?.draw(
-                            batch,
-                            globalX,
-                            globalY,
-                            width,
-                            height,
+                            batch = batch,
+                            x = globalX - originX,
+                            y = globalY - originY,
+                            originX = originX,
+                            originY = originY,
+                            width = width,
+                            height = height,
                             scaleX = globalScaleX,
                             scaleY = globalScaleY,
                             rotation = globalRotation,
                             color = progressBarColor,
-                            srcHeight = height - height * (1f - ratio)
+                            srcHeight = height - height * (1f - ratio),
                         )
                     }
                     FillMode.BOTTOM_TO_TOP -> {
                         progressNine?.draw(
                             batch,
-                            globalX,
-                            globalY,
-                            width,
-                            height,
+                            x = globalX - originX,
+                            y = globalY - originY,
+                            originX = originX,
+                            originY = originY,
+                            width = width,
+                            height = height,
                             scaleX = globalScaleX,
                             scaleY = globalScaleY,
                             rotation = globalRotation,
@@ -257,27 +267,31 @@ open class TextureProgress : Range() {
                 }
 
                 foregroundNine?.draw(
-                    batch,
-                    globalX,
-                    globalY,
-                    width,
-                    height,
+                    batch = batch,
+                    x = globalX - originX,
+                    y = globalY - originY,
+                    originX = originX,
+                    originY = originY,
+                    width = width,
+                    height = height,
                     scaleX = globalScaleX,
                     scaleY = globalScaleY,
                     rotation = globalRotation,
-                    color = foregroundColor
+                    color = foregroundColor,
                 )
             }
         } else {
             background?.let {
                 batch.draw(
-                    it,
-                    globalX,
-                    globalY,
+                    slice = it,
+                    x = globalX - originX,
+                    y = globalY - originY,
+                    originX = originX,
+                    originY = originY,
                     scaleX = globalScaleX,
                     scaleY = globalScaleY,
                     rotation = globalRotation,
-                    color = backgroundColor
+                    color = backgroundColor,
                 )
             }
             progressBar?.let {
@@ -291,11 +305,11 @@ open class TextureProgress : Range() {
                 when (fillMode) {
                     FillMode.LEFT_TO_RIGHT -> {
                         batch.draw(
-                            it,
-                            globalX,
-                            globalY,
-                            0f,
-                            0f,
+                            slice = it,
+                            x = globalX - originX,
+                            y = globalY - originY,
+                            originX = originX,
+                            originY = originY,
                             width = min(widthRatio, sliceWidth).toFloat(),
                             height = sliceHeight.toFloat(),
                             scaleX = globalScaleX,
@@ -305,16 +319,16 @@ open class TextureProgress : Range() {
                             srcY = sliceY,
                             srcWidth = min(widthRatio, sliceWidth),
                             srcHeight = sliceHeight,
-                            color = progressBarColor
+                            color = progressBarColor,
                         )
                     }
                     FillMode.RIGHT_TO_LEFT -> {
                         batch.draw(
-                            it,
-                            globalX + sliceWidth - widthRatio,
-                            globalY,
-                            0f,
-                            0f,
+                            slice = it,
+                            x = globalX + sliceWidth - widthRatio - originX,
+                            y = globalY - originY,
+                            originX = originX,
+                            originY = originY,
                             width = min(widthRatio, sliceWidth).toFloat(),
                             height = sliceHeight.toFloat(),
                             scaleX = globalScaleX,
@@ -324,16 +338,16 @@ open class TextureProgress : Range() {
                             srcY = sliceY,
                             srcWidth = min(widthRatio, sliceWidth),
                             srcHeight = sliceHeight,
-                            color = progressBarColor
+                            color = progressBarColor,
                         )
                     }
                     FillMode.TOP_TO_BOTTOM -> {
                         batch.draw(
-                            it,
-                            globalX,
-                            globalY,
-                            0f,
-                            0f,
+                            slice = it,
+                            x = globalX - originX,
+                            y = globalY - originY,
+                            originX = originX,
+                            originY = originY,
                             width = sliceWidth.toFloat(),
                             height = min(heightRatio, sliceHeight).toFloat(),
                             scaleX = globalScaleX,
@@ -343,16 +357,16 @@ open class TextureProgress : Range() {
                             srcY = sliceY,
                             srcWidth = sliceWidth,
                             srcHeight = min(heightRatio, sliceHeight),
-                            color = progressBarColor
+                            color = progressBarColor,
                         )
                     }
                     FillMode.BOTTOM_TO_TOP -> {
                         batch.draw(
-                            it,
-                            globalX,
-                            globalY + sliceHeight - heightRatio,
-                            0f,
-                            0f,
+                            slice = it,
+                            x = globalX - originX,
+                            y = globalY + sliceHeight - heightRatio - originY,
+                            originX = originX,
+                            originY = originY,
                             width = sliceWidth.toFloat(),
                             height = min(heightRatio, sliceHeight).toFloat(),
                             scaleX = globalScaleX,
@@ -362,20 +376,22 @@ open class TextureProgress : Range() {
                             srcY = sliceY + sliceHeight - heightRatio,
                             srcWidth = sliceWidth,
                             srcHeight = min(heightRatio, sliceHeight),
-                            color = progressBarColor
+                            color = progressBarColor,
                         )
                     }
                 }
             }
             foreground?.let {
                 batch.draw(
-                    it,
-                    globalX,
-                    globalY,
+                    slice = it,
+                    x = globalX - originX,
+                    y = globalY - originY,
+                    originX = originX,
+                    originY = originY,
                     scaleX = globalScaleX,
                     scaleY = globalScaleY,
                     rotation = globalRotation,
-                    color = foregroundColor
+                    color = foregroundColor,
                 )
             }
         }
@@ -447,6 +463,6 @@ open class TextureProgress : Range() {
         TOP_TO_BOTTOM,
 
         /** Progress fills from bottom to top. */
-        BOTTOM_TO_TOP
+        BOTTOM_TO_TOP,
     }
 }

--- a/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureRect.kt
+++ b/scene-graph/src/commonMain/kotlin/com/littlekt/graph/node/ui/TextureRect.kt
@@ -175,18 +175,20 @@ open class TextureRect : Control() {
                                 it,
                                 x = globalX + totalW,
                                 y = globalY + totalH,
+                                originX = originX,
+                                originY = originY,
                                 scaleX = globalScaleX,
                                 scaleY = globalScaleY,
                                 rotation = globalRotation,
-                                color = color
+                                color = color,
                             )
                         } else {
                             batch.draw(
-                                it.texture,
-                                globalX + totalW,
-                                globalY + totalH,
-                                0f,
-                                0f,
+                                texture = it.texture,
+                                x = globalX + totalW,
+                                y = globalY + totalH,
+                                originX = originX,
+                                originY = originY,
                                 width = min(width - totalW, sliceWidth),
                                 height = min(height - totalH, sliceHeight),
                                 scaleX = globalScaleX,
@@ -198,7 +200,7 @@ open class TextureRect : Control() {
                                 srcHeight = min(height - totalH, sliceHeight).toInt(),
                                 flipX = flipX,
                                 flipY = flipY,
-                                color = color
+                                color = color,
                             )
                         }
                         totalW += sliceWidth
@@ -207,11 +209,11 @@ open class TextureRect : Control() {
                 }
             } else {
                 batch.draw(
-                    it.texture,
-                    globalX + offsetX,
-                    globalY + offsetY,
-                    0f,
-                    0f,
+                    texture = it.texture,
+                    x = globalX + offsetX,
+                    y = globalY + offsetY,
+                    originX = originX,
+                    originY = originY,
                     width = newWidth,
                     height = newHeight,
                     scaleX = globalScaleX,
@@ -223,7 +225,7 @@ open class TextureRect : Control() {
                     srcHeight = sliceHeight.toInt(),
                     flipX = flipX,
                     flipY = flipY,
-                    color = color
+                    color = color,
                 )
             }
         }


### PR DESCRIPTION
- Add `CanvasItem.pivotX` and `CanvasItem.pivotY` that accepts values from `0f` and `1f`. `0f, 0f` being bottom-left, by default. `1f,1f` being top-right.
- Add `Control.originX` and `Control.originY` which is the calculation of `width * pivotX` and `height * pivotY`. These values are used in the rendering and when containers fit children.


```kotlin
button {
    // moves anchor point to center of parent
    anchorX = 0.5f
    anchorY = 0.5f
    // moves pivot to center of control
    pivotX = 0.5f
    pivotY = 0.5f
    text = "Press me!"
}

node2d {
    pivotX = 0.5f
    pivotY = 0.5f
    val width = 50f
    val height = 100f
    onRender += {
        // node2d doesn't have a built-in width or height so we would need to calculate it ourselves
        val originX = width * pivotX
        val originY = height * pivotY
        batch.draw(slice, x = globalX - originX, y =globalY - originY, originX = originX, originY = originY, width = width, height = height, rotation = globalRotation)
    }
}
```