### PR TITLE
Fix open no join paths

### DIFF
--- a/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/shape/PathDrawer.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/graphics/g2d/shape/PathDrawer.kt
@@ -90,8 +90,8 @@ internal class PathDrawer(batchManager: BatchManager, private val lineDrawer: Li
         }
         if (!open) {
             lineDrawer.line(
-                path[path.size - 2],
-                path[path.size - 1],
+                path[size - 2],
+                path[size - 1],
                 path[0],
                 path[1],
                 thickness,


### PR DESCRIPTION
The function previously used path.size instead of the passed in capacity
(fix untested)