### PR TITLE
add functionality to add own Materials creation strategies based off glTF material during loading

### DIFF
--- a/core/src/commonMain/kotlin/com/littlekt/AssetProvider.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/AssetProvider.kt
@@ -6,7 +6,7 @@ import com.littlekt.audio.AudioClip
 import com.littlekt.audio.AudioStream
 import com.littlekt.file.UnsupportedFileTypeException
 import com.littlekt.file.gltf.GltfData
-import com.littlekt.file.gltf.GltfModelConfig
+import com.littlekt.file.gltf.GltfLoaderConfig
 import com.littlekt.file.ldtk.LDtkMapLoader
 import com.littlekt.file.vfs.*
 import com.littlekt.graphics.Pixmap
@@ -366,4 +366,4 @@ class BitmapFontAssetParameter(val preloadedTextures: List<TextureSlice> = listO
  *
  * @param config configuration for creating a renderable model.
  */
-class GltfModelAssetParameter(val config: GltfModelConfig) : GameAssetParameters
+class GltfModelAssetParameter(val config: GltfLoaderConfig) : GameAssetParameters

--- a/core/src/commonMain/kotlin/com/littlekt/file/gltf/GltfModelConfig.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/file/gltf/GltfModelConfig.kt
@@ -1,23 +1,166 @@
 package com.littlekt.file.gltf
 
+import com.littlekt.graphics.Color
+import com.littlekt.graphics.EmptyTexture
+import com.littlekt.graphics.Texture
+import com.littlekt.graphics.g3d.material.Material
 import com.littlekt.graphics.g3d.material.PBRMaterial
 import com.littlekt.graphics.g3d.material.UnlitMaterial
+import com.littlekt.graphics.webgpu.Device
+import com.littlekt.graphics.webgpu.TextureFormat
+import com.littlekt.math.Vec3f
+import com.littlekt.resources.Textures
 
 /**
  * A configuration class that is used when generating a GLtf model.
  *
- * @param pbr if `true`, then generate a Model with a [PBRMaterial]; otherwise will use an
- *   [UnlitMaterial]
  * @param castShadows if `true`, then designate the model to cast shadows.
  * @author Colton Daily
  * @date 12/8/2024
  */
-data class GltfModelConfig(val pbr: Boolean, val castShadows: Boolean)
+data class GltfModelConfig(val castShadows: Boolean)
 
-/** Creates a [GltfModelConfig], specific for PBR usage. */
-fun GltfModelPbrConfig(castShadows: Boolean = true) =
-    GltfModelConfig(pbr = true, castShadows = castShadows)
+/**
+ * @param modelConfig the basic model config
+ * @param materialStrategy the material strategy for when a primitive has a glTF material
+ * @param fallbackMaterialStrategy the material strategy for when a primitive doesn't have a glTF
+ *   material.
+ */
+data class GltfLoaderConfig(
+    val modelConfig: GltfModelConfig,
+    val materialStrategy: GltfModelMaterialStrategy,
+    val fallbackMaterialStrategy: GltfModelFallbackMaterialStrategy,
+)
 
-/** Creates a [GltfModelConfig], specific for unlit usage. */
-fun GltfModelUnlitConfig(castShadows: Boolean = true) =
-    GltfModelConfig(pbr = false, castShadows = castShadows)
+/** A strategy for creating a [Material] for when a glTF primitive does not have a glTF material. */
+abstract class GltfModelFallbackMaterialStrategy {
+    abstract fun createMaterial(device: Device): Material
+}
+
+/** Creates an [UnlitMaterial] that defaults to a white texture. */
+class UnlitMaterialFallbackStrategy : GltfModelFallbackMaterialStrategy() {
+    override fun createMaterial(device: Device): Material =
+        UnlitMaterial(device, Textures.textureWhite)
+}
+
+/** A strategy for creating a [Material] for a Gltf primitive. */
+abstract class GltfModelMaterialStrategy {
+
+    /**
+     * Create a material when converting a [GltfData] to a renderable model.
+     *
+     * @param config basic gltf model config to adhere to
+     * @param device gpu context
+     * @param preferredFormat preferred format of textures
+     * @param gltfMaterial the gltf material that needs created
+     * @param gltfFile the gltf file as a whole
+     * @return a newly created [Material]
+     */
+    abstract fun createMaterial(
+        config: GltfModelConfig,
+        device: Device,
+        preferredFormat: TextureFormat,
+        gltfMaterial: GltfMaterial,
+        gltfFile: GltfData,
+    ): Material
+
+    /** Helper method to load textures for materials. */
+    protected fun GltfTextureInfo?.loadTexture(
+        device: Device,
+        preferredFormat: TextureFormat,
+        gltfFile: GltfData,
+    ): Texture? = this?.getTexture(gltfFile, gltfFile.root, device, preferredFormat)
+}
+
+/** A [GltfModelMaterialStrategy] for creating a [PBRMaterial] from glTF data. */
+class PBRMaterialStrategy : GltfModelMaterialStrategy() {
+    override fun createMaterial(
+        config: GltfModelConfig,
+        device: Device,
+        preferredFormat: TextureFormat,
+        gltfMaterial: GltfMaterial,
+        gltfFile: GltfData,
+    ): Material {
+        val baseColorFactor = gltfMaterial.pbrMetallicRoughness.baseColorFactor
+        return PBRMaterial(
+            device = device,
+            metallicFactor = gltfMaterial.pbrMetallicRoughness.metallicFactor,
+            roughnessFactor = gltfMaterial.pbrMetallicRoughness.roughnessFactor,
+            metallicRoughnessTexture =
+                gltfMaterial.pbrMetallicRoughness.metallicRoughnessTexture?.loadTexture(
+                    device,
+                    preferredFormat,
+                    gltfFile,
+                ),
+            normalTexture =
+                gltfMaterial.normalTexture?.loadTexture(device, preferredFormat, gltfFile),
+            emissiveFactor =
+                if (gltfMaterial.emissiveFactor.isNotEmpty()) {
+                    Vec3f(
+                        gltfMaterial.emissiveFactor[0],
+                        gltfMaterial.emissiveFactor[1],
+                        gltfMaterial.emissiveFactor[2],
+                    )
+                } else {
+                    Vec3f(0f)
+                },
+            emissiveTexture =
+                gltfMaterial.emissiveTexture.loadTexture(device, preferredFormat, gltfFile),
+            baseColorFactor =
+                Color(
+                    baseColorFactor[0],
+                    baseColorFactor[1],
+                    baseColorFactor[2],
+                    baseColorFactor[3],
+                ),
+            baseColorTexture =
+                gltfMaterial.pbrMetallicRoughness.baseColorTexture?.loadTexture(
+                    device,
+                    preferredFormat,
+                    gltfFile,
+                ) ?: EmptyTexture(device, preferredFormat, 0, 0),
+            transparent = gltfMaterial.alphaMode == GltfAlphaMode.Blend,
+            doubleSided = gltfMaterial.doubleSided,
+            alphaCutoff = gltfMaterial.alphaCutoff,
+            castShadows = config.castShadows,
+        )
+    }
+}
+
+class UnlitMaterialStrategy : GltfModelMaterialStrategy() {
+    override fun createMaterial(
+        config: GltfModelConfig,
+        device: Device,
+        preferredFormat: TextureFormat,
+        gltfMaterial: GltfMaterial,
+        gltfFile: GltfData,
+    ): Material {
+        val baseColorFactor = gltfMaterial.pbrMetallicRoughness.baseColorFactor
+        return UnlitMaterial(
+            device = device,
+            baseColorFactor =
+                Color(
+                    baseColorFactor[0],
+                    baseColorFactor[1],
+                    baseColorFactor[2],
+                    baseColorFactor[3],
+                ),
+            baseColorTexture =
+                gltfMaterial.pbrMetallicRoughness.baseColorTexture?.loadTexture(
+                    device,
+                    preferredFormat,
+                    gltfFile,
+                ) ?: EmptyTexture(device, preferredFormat, 0, 0),
+            transparent = gltfMaterial.alphaMode != GltfAlphaMode.Opaque,
+            doubleSided = gltfMaterial.doubleSided,
+        )
+    }
+}
+
+/** Creates a [GltfLoaderConfig], specific for PBR usage. */
+fun GltfLoaderPbrConfig(modelConfig: GltfModelConfig = GltfModelConfig(castShadows = true)) =
+    GltfLoaderConfig(modelConfig, PBRMaterialStrategy(), UnlitMaterialFallbackStrategy())
+
+/** Creates a [GltfLoaderConfig], specific for unlit usage. */
+fun GltfLoaderUnlitConfig(modelConfig: GltfModelConfig = GltfModelConfig(castShadows = true)) =
+    GltfLoaderConfig(modelConfig, UnlitMaterialStrategy(), UnlitMaterialFallbackStrategy())

--- a/core/src/commonMain/kotlin/com/littlekt/file/vfs/VfsLoaders.kt
+++ b/core/src/commonMain/kotlin/com/littlekt/file/vfs/VfsLoaders.kt
@@ -6,10 +6,7 @@ import com.littlekt.file.ByteBuffer
 import com.littlekt.file.UnsupportedFileTypeException
 import com.littlekt.file.atlas.AtlasInfo
 import com.littlekt.file.atlas.AtlasPage
-import com.littlekt.file.gltf.GltfData
-import com.littlekt.file.gltf.GltfModelConfig
-import com.littlekt.file.gltf.GltfModelPbrConfig
-import com.littlekt.file.gltf.toModel
+import com.littlekt.file.gltf.*
 import com.littlekt.file.ldtk.LDtkMapData
 import com.littlekt.file.ldtk.LDtkMapLoader
 import com.littlekt.file.tiled.TiledMapData
@@ -382,11 +379,11 @@ suspend fun VfsFile.readGltf(): GltfData {
  * Reads a `.glb` or `.gltf` into a `GltfData` object and then converts it to a [Model].
  *
  * @param config the configuration to use when generating the [Model]. Defaults to
- *   [GltfModelPbrConfig].
+ *   [GltfLoaderPbrConfig].
  * @param preferredFormat the preferred [TextureFormat] to be used when loading the model texture.
  */
 suspend fun VfsFile.readGltfModel(
-    config: GltfModelConfig = GltfModelPbrConfig(),
+    config: GltfLoaderConfig = GltfLoaderPbrConfig(),
     preferredFormat: TextureFormat =
         if (vfs.context.graphics.preferredFormat.srgb) TextureFormat.RGBA8_UNORM_SRGB
         else TextureFormat.RGBA8_UNORM,

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/ModelInstancingExample.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/ModelInstancingExample.kt
@@ -3,7 +3,7 @@ package com.littlekt.examples
 import com.littlekt.Context
 import com.littlekt.ContextListener
 import com.littlekt.async.KtScope
-import com.littlekt.file.gltf.GltfModelUnlitConfig
+import com.littlekt.file.gltf.GltfLoaderUnlitConfig
 import com.littlekt.file.vfs.readGltfModel
 import com.littlekt.graphics.Color
 import com.littlekt.graphics.PerspectiveCamera
@@ -56,7 +56,7 @@ class ModelInstancingExample(context: Context) : ContextListener(context) {
             )
         var depthFrame = depthTexture.createView()
         val duckModel =
-            resourcesVfs["models/Duck.glb"].readGltfModel(config = GltfModelUnlitConfig())
+            resourcesVfs["models/Duck.glb"].readGltfModel(config = GltfLoaderUnlitConfig())
         val duckModelInstances = mutableListOf<Scene>()
 
         KtScope.launch {

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/PBRExample.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/PBRExample.kt
@@ -2,7 +2,7 @@ package com.littlekt.examples
 
 import com.littlekt.Context
 import com.littlekt.ContextListener
-import com.littlekt.file.gltf.GltfModelPbrConfig
+import com.littlekt.file.gltf.GltfLoaderPbrConfig
 import com.littlekt.graph.node.ui.Control
 import com.littlekt.graph.node.ui.column
 import com.littlekt.graph.node.ui.label
@@ -19,6 +19,7 @@ import com.littlekt.graphics.g3d.util.UnlitMaterialPipelineProvider
 import com.littlekt.graphics.webgpu.*
 import com.littlekt.input.Key
 import com.littlekt.math.Vec3f
+import com.littlekt.math.random
 
 /**
  * An example using a simple Orthographic camera to move around a texture.
@@ -40,7 +41,32 @@ class PBRExample(context: Context) : ContextListener(context) {
         )
         environment.setAmbientLight(AmbientLight(color = Color(0.002f, 0.002f, 0.002f)))
         environment.addPointLight(PointLight(Vec3f(0f, 2.5f, 0f), color = Color.GREEN, range = 4f))
-        environment.addPointLight(PointLight(Vec3f(8.95f, 2f, 3.15f), range = 4f))
+        environment.addPointLight(
+            PointLight(Vec3f(8.95f, 2f, 3.15f), range = 4f, color = Color.RED)
+        )
+        environment.addPointLight(
+            PointLight(Vec3f(-9.45f, 2f, -3.59f), range = 4f, color = Color.BLUE)
+        )
+        environment.addPointLight(
+            PointLight(Vec3f(-9.45f, 2f, 3.15f), range = 4f, color = Color.GREEN)
+        )
+        environment.addPointLight(
+            PointLight(Vec3f(8.95f, 2f, -3.59f), range = 4f, color = Color.YELLOW)
+        )
+
+        repeat(1024) {
+            environment.addPointLight(
+                PointLight(
+                    Vec3f(
+                        (-9.45f..8.95f).random(),
+                        (0.5f..7.2f).random(),
+                        (-3.59f..3.15f).random(),
+                    ),
+                    range = 2f,
+                    color = Color((0f..1f).random(), (0f..1f).random(), (0f..1f).random(), 1f),
+                )
+            )
+        }
 
         val surfaceCapabilities = graphics.surfaceCapabilities
         val preferredFormat = graphics.preferredFormat
@@ -95,7 +121,7 @@ class PBRExample(context: Context) : ContextListener(context) {
             listOf(
                 GltfModel(
                     resourcesVfs["models/sponza.glb"],
-                    GltfModelPbrConfig(),
+                    GltfLoaderPbrConfig(),
                     environment,
                     1f,
                     Vec3f.ZERO,

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/SimpleGltfExample.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/SimpleGltfExample.kt
@@ -2,8 +2,8 @@ package com.littlekt.examples
 
 import com.littlekt.Context
 import com.littlekt.ContextListener
-import com.littlekt.file.gltf.GltfModelPbrConfig
-import com.littlekt.file.gltf.GltfModelUnlitConfig
+import com.littlekt.file.gltf.GltfLoaderPbrConfig
+import com.littlekt.file.gltf.GltfLoaderUnlitConfig
 import com.littlekt.file.vfs.TextureOptions
 import com.littlekt.file.vfs.readTexture
 import com.littlekt.graphics.Color
@@ -84,14 +84,14 @@ class SimpleGltfExample(context: Context) : ContextListener(context) {
             listOf(
                 GltfModel(
                     resourcesVfs["models/Duck.glb"],
-                    GltfModelUnlitConfig(),
+                    GltfLoaderUnlitConfig(),
                     environment,
                     1f,
                     Vec3f(-1f, 0f, 0f),
                 ),
                 GltfModel(
                     resourcesVfs["models/flighthelmet/FlightHelmet.gltf"],
-                    GltfModelPbrConfig(),
+                    GltfLoaderPbrConfig(),
                     pbrEnvironment,
                     4f,
                     Vec3f(1f, 0f, 0f),

--- a/examples/src/commonMain/kotlin/com/littlekt/examples/utils.kt
+++ b/examples/src/commonMain/kotlin/com/littlekt/examples/utils.kt
@@ -2,7 +2,7 @@ package com.littlekt.examples
 
 import com.littlekt.Context
 import com.littlekt.async.VfsScope
-import com.littlekt.file.gltf.GltfModelConfig
+import com.littlekt.file.gltf.GltfLoaderConfig
 import com.littlekt.file.vfs.VfsFile
 import com.littlekt.file.vfs.readGltfModel
 import com.littlekt.graphics.Camera
@@ -22,10 +22,10 @@ import com.littlekt.math.geom.degrees
 import com.littlekt.math.geom.radians
 import com.littlekt.util.datastructure.fastForEach
 import com.littlekt.util.milliseconds
+import kotlin.math.asin
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
-import kotlin.math.asin
 
 fun SurfaceTexture.isValid(context: Context, onConfigure: () -> SurfaceConfiguration): Boolean {
     val surfaceTexture = this
@@ -69,7 +69,7 @@ fun Context.addCloseOnEsc() {
 
 data class GltfModel(
     val file: VfsFile,
-    val config: GltfModelConfig,
+    val config: GltfLoaderConfig,
     val environment: Environment,
     val scale: Float,
     val translate: Vec3f,


### PR DESCRIPTION
- Adds a `GltfModelMaterialStrategy` for handling a primitive with a glTF material
  - Has two implementations:
    - `PBRMaterialStrategy`: for PBR rendering
    - `UnlitMaterialStrategy`: for simple unlit rendering
- Adds a `GltfModelFallbackMaterialStrategy` for handling when a glTF primitive does not have a material.
   -  `UnlitMaterialFallbackStrategy`: simple white texture coloring fallback.
